### PR TITLE
docs: add Android build guide and scripts for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,20 @@
 # nostr-vpn
 
-> Main development is on [decentralized git](https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/nostr-vpn): `htree://npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/nostr-vpn`
+`nostr-vpn` is a Rust workspace for a Tailscale-style mesh VPN control plane built on:
 
-## Downloads
+- Nostr relays for peer signaling and encrypted presence exchange
+- `boringtun` for userspace WireGuard-compatible tunnel handling
+- a CLI daemon and a Tauri desktop app that operate on the same config/runtime model
 
-- [Latest release](https://github.com/mmalmi/nostr-vpn/releases/latest)
-
-Current release artifacts:
-
-- Apple Silicon macOS desktop app
-- Windows x64 desktop installer
-- Android arm64 APK/AAB
-- Headless CLI archives for Apple Silicon macOS, Windows x64, Linux x86_64, and Linux arm64
-
-Intel macOS is source-only. iOS app code is in the repo, but releases do not publish an iOS artifact yet.
-
-## Overview
-
-`nostr-vpn` is a Rust workspace for a Tailscale-style mesh VPN control plane built on Nostr signaling and userspace WireGuard. It includes the `nvpn` CLI plus a Tauri/Svelte app codebase that targets desktop and mobile platforms.
-
-<p align="center">
-  <img src="docs/images/desktop-gui-overview.png" alt="Nostr VPN desktop app showing a connected network, device identity, status badges, and join controls." width="900">
-</p>
-
-It currently ships:
+This repo is not just one binary. It currently ships:
 
 | Component | Purpose |
 | --- | --- |
 | `nvpn` | Main CLI for config, daemon lifecycle, networking, diagnostics, and tunnel sessions |
-| `nostr-vpn-gui` | Tauri + Svelte GUI app for desktop releases plus Android/iOS targets |
+| `nostr-vpn-gui` | Tauri + Svelte desktop app that manages the same `nvpn` daemon and config |
 | `nostr-vpn-relay` | Minimal local websocket relay used for integration and e2e testing |
 | `nvpn-reflector` | Minimal UDP reflector used for NAT discovery and hole-punch testing |
 | `nostr-vpn-core` | Shared library for config, signaling, NAT helpers, diagnostics, MagicDNS, and WireGuard helpers |
-
-## Platform status
-
-| Platform | Current status |
-| --- | --- |
-| Apple Silicon macOS | Signed desktop app in releases, plus a CLI tarball |
-| Windows x64 | Desktop installer and CLI zip in releases; a manual GitHub Actions smoke workflow builds both CLI and GUI |
-| Android arm64 | APK/AAB artifacts built in the release workflow |
-| iOS | Tauri mobile code, Packet Tunnel integration, and generated Apple project files are checked in, but releases do not publish an iOS artifact yet |
-| Linux | CLI-focused today: release CLI tarballs plus Docker e2e coverage, but no packaged desktop app release |
 
 ## What the project does today
 
@@ -52,12 +25,12 @@ It currently ships:
 - Tracks peer endpoints, including NAT-discovered public endpoints and hole-punch attempts
 - Supports route advertisement and exit-node selection
 - Exposes JSON status, relay checks, network diagnostics, and doctor bundles
-- Includes a desktop GUI with service-first session control, invite QR/import flows, tray integration, autostart, timed LAN pairing, MagicDNS controls, health reporting, and port-mapping status
+- Includes a desktop GUI with service-first session control, invite QR/import flows, tray integration, autostart, LAN discovery, MagicDNS controls, health reporting, and port-mapping status
 - Includes Linux-focused Docker e2e coverage for signaling, mesh formation, NAT traversal, and exit-node routing
 
 ## Default relays
 
-Used when a config does not specify its own relay list:
+These are compiled into `nostr-vpn-core` and used when a config does not specify its own relay list:
 
 - `wss://temp.iris.to`
 - `wss://relay.damus.io`
@@ -76,7 +49,7 @@ By default, `nvpn` uses the OS config directory:
 
 The config contains:
 
-- global app settings such as autoconnect, tray behavior, and MagicDNS suffix
+- global app settings such as autoconnect, LAN discovery, tray behavior, and MagicDNS suffix
 - Nostr settings including relay URLs and identity keys
 - NAT settings including STUN servers, reflectors, and discovery timeout
 - node settings including endpoint, tunnel IP, listen port, and advertised routes
@@ -97,7 +70,7 @@ Prerequisites:
 
 CI currently runs:
 
-```bash
+```
 corepack enable
 pnpm --dir crates/nostr-vpn-gui install --frozen-lockfile
 pnpm --dir crates/nostr-vpn-gui build
@@ -107,69 +80,61 @@ cargo clippy --workspace --exclude nostr-vpn-gui --all-targets -- -D warnings
 cargo test --workspace --exclude nostr-vpn-gui
 ```
 
-Additional automation:
+Useful extra local validation when touching the Tauri shell:
 
-- `.github/workflows/windows-smoke.yml` can manually build the Windows CLI and GUI on `windows-latest`
-- `.github/workflows/release.yml` publishes Apple Silicon macOS, Windows x64, and Android arm64 APK/AAB app artifacts, plus CLI archives for Apple Silicon macOS, Windows x64, Linux x86_64, and Linux arm64
-
-If you touch the Tauri shell:
-
-```bash
+```
 cargo check -p nostr-vpn-gui
 ```
 
 If you only want the CLI and test binaries:
 
-```bash
+```
 cargo build -p nostr-vpn-cli -p nostr-vpn-relay
 ```
 
-## Install `nvpn`
+## Build for Android (Windows)
 
-Latest releases publish CLI archives for Apple Silicon macOS, Windows x64, Linux x86_64, and Linux arm64. The quick installer below auto-detects only Apple Silicon macOS and Linux:
+The Android port is fully implemented in the codebase. To build the APK on Windows, see [docs/android-build-windows.md](docs/android-build-windows.md) for the complete setup guide, or use the automated scripts:
 
-```bash
-case "$(uname -s)/$(uname -m)" in
-  Darwin/arm64) ASSET=nvpn-aarch64-apple-darwin.tar.gz ;;
-  Linux/x86_64) ASSET=nvpn-x86_64-unknown-linux-musl.tar.gz ;;
-  Linux/aarch64|Linux/arm64) ASSET=nvpn-aarch64-unknown-linux-musl.tar.gz ;;
-  Darwin/x86_64)
-    echo "Prebuilt Intel macOS releases have been sunset. Build from source or use an older release." >&2
-    exit 1
-    ;;
-  *)
-    echo "Unsupported platform: $(uname -s)/$(uname -m)" >&2
-    exit 1
-    ;;
-esac
-curl -fsSL "https://github.com/mmalmi/nostr-vpn/releases/latest/download/${ASSET}" | tar -xz && cd nvpn && ./install.sh
+```powershell
+# Build the APK
+.\scripts\build_android_windows.ps1
+
+# Sign and install on a connected device
+.\scripts\sign_and_install_android.ps1
 ```
 
-That command supports Apple Silicon macOS and Linux. On Intel macOS it exits with a clear message. The installer creates the target directory when needed and defaults to `/opt/homebrew/bin` on Apple Silicon macOS when that location exists or is already in `PATH`; otherwise it uses `/usr/local/bin`.
+Prerequisites: Rust with Android targets, JDK 17, Node.js, pnpm, Android SDK/NDK, and the Tauri CLI. The guide covers installing all of these from scratch.
 
-On Windows, download the `nvpn-<version>-x86_64-pc-windows-msvc.zip` release asset and run `nvpn.exe`, or build from source.
+## Install `nvpn`
+
+Quick install for servers, VPSes, and other headless macOS/Linux hosts:
+
+```
+curl -fsSL https://github.com/mmalmi/nostr-vpn/releases/latest/download/nvpn-$(uname -m | sed 's/arm64/aarch64/')-$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/unknown-linux-musl/').tar.gz | tar -xz && cd nvpn && ./install.sh
+```
 
 From source:
 
-```bash
+```
 cargo install --path crates/nostr-vpn-cli --bin nvpn
 ```
 
-This is the supported route on Intel macOS.
+If you already have a packaged CLI release artifact, extract it and run:
 
-If you already have a release tarball, extract it and run:
-
-```bash
+```
 ./install.sh
 ```
 
-You can also pass a custom destination directory, for example `./install.sh ~/.local/bin`.
+That installer places `nvpn` into `/usr/local/bin` by default.
+
+If you want the desktop app instead of the headless CLI flow, GitHub Releases currently publish the signed Apple Silicon macOS app as `nostr-vpn-macos-arm64.zip`.
 
 ## CLI quickstart
 
 Create or refresh config and generate keys:
 
-```bash
+```
 nvpn init \
   --participant npub1...alice \
   --participant npub1...bob
@@ -177,7 +142,7 @@ nvpn init \
 
 Adjust persisted settings if needed:
 
-```bash
+```
 nvpn set \
   --relay ws://127.0.0.1:8080 \
   --endpoint 192.0.2.10:51820 \
@@ -186,29 +151,29 @@ nvpn set \
 
 Run a full foreground session:
 
-```bash
+```
 nvpn connect
 ```
 
-Shorter lifecycle commands:
+If you only want to publish presence or bring the node down without running the full long-lived session, use:
 
-```bash
+```
 nvpn up
 nvpn down
 ```
 
-Daemonized flow used by the GUI:
+Or run the daemonized flow the GUI also uses:
 
-```bash
+```
 nvpn start --daemon --connect
 nvpn pause
 nvpn resume
 nvpn stop
 ```
 
-For persistent privileged startup:
+If you want persistent privileged startup without repeated prompts, install the system service once:
 
-```bash
+```
 sudo nvpn service install
 nvpn service status
 ```
@@ -225,7 +190,7 @@ The service implementation targets:
 
 Inspect runtime state:
 
-```bash
+```
 nvpn status --json
 nvpn netcheck --json
 nvpn doctor --json
@@ -233,13 +198,13 @@ nvpn doctor --json
 
 Write a support bundle:
 
-```bash
+```
 nvpn doctor --write-bundle /tmp/nvpn-doctor
 ```
 
 Advertise routes or use an exit node:
 
-```bash
+```
 nvpn set --advertise-routes 10.0.0.0/24,192.168.0.0/24
 nvpn set --advertise-exit-node true
 nvpn set --exit-node npub1...peer
@@ -247,11 +212,11 @@ nvpn set --exit-node npub1...peer
 
 Clear exit-node selection:
 
-```bash
+```
 nvpn set --exit-node off
 ```
 
-Lower-level commands:
+Low-level helper commands are also available when you want to work below the daemon/session layer:
 
 - `announce`
 - `listen`
@@ -264,15 +229,15 @@ Lower-level commands:
 - `ip`
 - `whois`
 
-## GUI app
+## Desktop GUI
 
-The GUI lives in [`crates/nostr-vpn-gui`](crates/nostr-vpn-gui). It is the Tauri/Svelte app codebase for the shipped desktop app, the Android build, and the in-repo iOS target.
+The GUI lives in [`crates/nostr-vpn-gui`](crates/nostr-vpn-gui) and is a Tauri app backed by the same config and daemon used by `nvpn`.
 
-The commands below are the desktop flow. Android and iOS use Tauri mobile tooling and the platform-specific code under `src-tauri/`.
+![Nostr VPN desktop app showing a connected network, device identity, status badges, and join controls.](docs/images/desktop-gui-overview.png)
 
 Run it in development:
 
-```bash
+```
 corepack enable
 pnpm --dir crates/nostr-vpn-gui install --frozen-lockfile
 pnpm --dir crates/nostr-vpn-gui tauri:dev
@@ -280,42 +245,40 @@ pnpm --dir crates/nostr-vpn-gui tauri:dev
 
 Build a packaged app:
 
-```bash
+```
 pnpm --dir crates/nostr-vpn-gui tauri:build
 ```
 
-Notes:
+Important behavior:
 
-- `tauri:dev` and `tauri:build` automatically prepare an `nvpn` sidecar binary for desktop targets
-- on desktop, the frontend shells out to `nvpn`; mobile targets use the in-app platform-specific VPN runtime code
-- the desktop app is service-first on supported platforms: install the background service first, then use the app for normal on/off control
-- the GUI exposes network membership, invite QR/import flows, relay state, session health, MagicDNS, exit-node selection, advertised routes, timed LAN pairing, LAN discovery, autostart, and tray controls
-- tagged releases currently publish Apple Silicon macOS, Windows x64, and Android arm64 app artifacts
-- the iOS target is checked in for source builds, but the release workflow does not currently publish an iOS artifact
+- `tauri:dev` and `tauri:build` automatically prepare an `nvpn` sidecar binary
+- the frontend does not run the VPN runtime itself; it shells out to `nvpn`
+- the app is service-first on supported platforms: install the background service first, then use the app for normal on/off control
+- the GUI exposes network membership, invite QR/import flows, relay state, session health, MagicDNS, exit-node selection, advertised routes, LAN discovery, autostart, and tray controls
 
 You can override which CLI binary the GUI uses with `NVPN_CLI_PATH`.
 
 ## Local relay and NAT test binaries
 
-For local integration testing:
+For local integration testing without public infrastructure:
 
 Run a websocket relay:
 
-```bash
+```
 cargo run -p nostr-vpn-relay --bin nostr-vpn-relay -- --bind 127.0.0.1:8080
 ```
 
 Run a UDP reflector:
 
-```bash
+```
 cargo run -p nostr-vpn-relay --bin nvpn-reflector -- --bind 127.0.0.1:3478
 ```
 
-The reflector is used by `nvpn nat-discover` and `nvpn hole-punch` in local and Docker e2e setups.
+The reflector is what `nvpn nat-discover` and `nvpn hole-punch` are designed to test against in local and Docker e2e setups.
 
 ## Docker end-to-end coverage
 
-Docker e2e scripts under [`scripts/`](scripts):
+The repo includes several real integration paths under [`scripts/`](scripts):
 
 - `./scripts/e2e-docker.sh`
   Verifies relay connectivity, `announce`/`listen`, manual `tunnel-up`, and ping across two containers.
@@ -332,27 +295,24 @@ Docker e2e scripts under [`scripts/`](scripts):
 - `./scripts/e2e-tauri-driver-docker.sh`
   Builds the GUI in a Linux container, runs a Tauri-driver smoke test, and writes a screenshot to `artifacts/screenshots/tauri-driver-e2e.png`.
 
-These flows are Linux-oriented because they require real tunnel devices and container networking privileges.
+The Docker e2e flows are Linux-oriented because they require real tunnel devices and container networking privileges.
 
 ## Workspace layout
 
 - [`Cargo.toml`](Cargo.toml): workspace definition
 - [`crates/nostr-vpn-core`](crates/nostr-vpn-core): shared config, signaling, diagnostics, MagicDNS, NAT, and WireGuard helpers
 - [`crates/nostr-vpn-cli`](crates/nostr-vpn-cli): `nvpn` CLI and daemon implementation
-- [`crates/nostr-vpn-gui`](crates/nostr-vpn-gui): Tauri/Svelte GUI app for desktop plus Android/iOS targets
+- [`crates/nostr-vpn-gui`](crates/nostr-vpn-gui): Tauri/Svelte desktop app
 - [`crates/nostr-vpn-relay`](crates/nostr-vpn-relay): test relay and reflector binaries
 - [`scripts`](scripts): Docker and GUI smoke-test entrypoints
 
 ## Release workflow notes
 
-Release workflow ([`.github/workflows/release.yml`](.github/workflows/release.yml)):
+The release workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml):
 
 - runs on pushed `v*` tags or manual dispatch
 - verifies frontend build, formatting, clippy, and tests before publishing artifacts
-- publishes CLI archives for Apple Silicon macOS, Windows x64, Linux x86_64, and Linux arm64
-- publishes Apple Silicon macOS as `nostr-vpn-<version>-macos-arm64.zip` containing a signed, notarized `Nostr VPN.app`
-- publishes Windows x64 as `nostr-vpn-<version>-windows-x64-setup.exe`
-- publishes Android arm64 release artifacts as APK/AAB files
-- does not currently publish an iOS release artifact
+- publishes macOS and Linux CLI archives as `nvpn-<target>.tar.gz`
+- publishes Apple Silicon macOS as `nostr-vpn-macos-arm64.zip` containing a signed, notarized `Nostr VPN.app`
 - requires the macOS signing and notarization secrets to be configured before a release can publish the macOS app
 - uses autogenerated GitHub release notes

--- a/docs/android-build-windows.md
+++ b/docs/android-build-windows.md
@@ -1,0 +1,236 @@
+# Building nostr-vpn for Android on Windows
+
+This guide walks through setting up a complete Android build environment on Windows and producing a signed APK from the existing codebase.
+
+> The Android port is already fully implemented in the repo. This document covers **environment setup and build reproduction only**.
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|------|----------------|---------|
+| Rust (stable) | 1.78+ | Compiler + cross-compilation targets |
+| JDK | 17 | Android Gradle toolchain |
+| Node.js | 22 LTS+ | Frontend build (Vite/Svelte) |
+| pnpm | 8+ | Package manager for frontend |
+| Android SDK | API 34+ | Android platform |
+| Android NDK | r28c (28.2.x) | Native cross-compilation |
+| Android Build-Tools | 34.0+ | APK signing (`apksigner`) |
+| Tauri CLI | 2.x | Build orchestration |
+
+---
+
+## Step 1 — Rust and Android targets
+
+If Rust is not installed, get it from [rustup.rs](https://rustup.rs/).
+
+```powershell
+# Add all Android cross-compilation targets
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+```
+
+Verify:
+
+```powershell
+rustup target list --installed | Select-String android
+# Should list all four targets
+```
+
+## Step 2 — JDK 17
+
+Android Gradle requires JDK 17 (not 8, not 21).
+
+```powershell
+winget install EclipseAdoptium.Temurin.17.JDK --accept-source-agreements --accept-package-agreements
+```
+
+Default install path: `C:\Program Files\Eclipse Adoptium\jdk-17.x.x-hotspot`
+
+## Step 3 — Node.js and pnpm
+
+```powershell
+# Node.js LTS
+winget install OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
+
+# pnpm (after restarting your terminal so node is in PATH)
+npm install -g pnpm
+```
+
+## Step 4 — Android SDK, NDK, and platform tools
+
+If you already have Android Studio installed, use its SDK Manager. Otherwise, install the command-line tools manually:
+
+```powershell
+# Download cmdline-tools
+Invoke-WebRequest -Uri "https://dl.google.com/android/repository/commandlinetools-win-11076708_latest.zip" -OutFile cmdline-tools.zip
+Expand-Archive cmdline-tools.zip -DestinationPath "$env:LOCALAPPDATA\Android\Sdk\cmdline-tools"
+Rename-Item "$env:LOCALAPPDATA\Android\Sdk\cmdline-tools\cmdline-tools" "latest"
+Remove-Item cmdline-tools.zip
+
+# Install NDK, platform, and build-tools
+$sdkmanager = "$env:LOCALAPPDATA\Android\Sdk\cmdline-tools\latest\bin\sdkmanager.bat"
+& $sdkmanager --install "ndk;28.2.13676358" "platforms;android-36" "build-tools;36.0.0" "platform-tools"
+```
+
+Accept all licenses when prompted.
+
+## Step 5 — Tauri CLI
+
+```powershell
+cargo install tauri-cli --version "^2"
+```
+
+## Step 6 — Environment variables
+
+Add these to your PowerShell profile (`$PROFILE`) or set them before each build session:
+
+```powershell
+$env:JAVA_HOME        = "C:\Program Files\Eclipse Adoptium\jdk-17.0.18.8-hotspot"
+$env:ANDROID_HOME     = "$env:LOCALAPPDATA\Android\Sdk"
+$env:ANDROID_SDK_ROOT = "$env:LOCALAPPDATA\Android\Sdk"
+$env:NDK_HOME         = "$env:LOCALAPPDATA\Android\Sdk\ndk\28.2.13676358"
+$env:ANDROID_NDK_HOME = "$env:LOCALAPPDATA\Android\Sdk\ndk\28.2.13676358"
+$env:PATH             = "$env:JAVA_HOME\bin;C:\Program Files\nodejs;$env:APPDATA\npm;$env:PATH"
+```
+
+> **Adjust paths** to match your actual installed versions. The JDK and NDK version numbers in the paths will differ on your machine.
+
+## Step 7 — Verify everything
+
+```powershell
+rustc --version              # 1.78+
+java -version                # 17.x
+node --version               # 22.x+
+pnpm --version               # 8.x+
+cargo tauri --version         # 2.x
+adb --version                # present
+echo $env:NDK_HOME           # points to NDK directory
+```
+
+---
+
+## Building the APK
+
+### Install frontend dependencies
+
+```powershell
+pnpm --dir crates/nostr-vpn-gui install --frozen-lockfile
+```
+
+### Build (debug)
+
+```powershell
+pnpm --dir crates/nostr-vpn-gui exec tauri android build --target aarch64 --apk --debug
+```
+
+### Build (release)
+
+```powershell
+pnpm --dir crates/nostr-vpn-gui exec tauri android build --target aarch64 --apk --ci
+```
+
+The APK lands at:
+
+```
+crates/nostr-vpn-gui/src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+```
+
+> Use `--target aarch64` for modern phones (95%+ of devices). Omit `--target` to build for all architectures (larger APK).
+
+---
+
+## Signing and installing
+
+The release APK is unsigned. Sign it before installing on a device.
+
+### Quick sign with debug keystore
+
+```powershell
+$buildTools = "$env:LOCALAPPDATA\Android\Sdk\build-tools\36.0.0"
+$debugKs    = "$env:USERPROFILE\.android\debug.keystore"
+
+# Generate debug keystore if it doesn't exist
+if (-not (Test-Path $debugKs)) {
+    keytool -genkey -v -keystore $debugKs -storepass android -alias androiddebugkey `
+      -keypass android -keyalg RSA -keysize 2048 -validity 10000 `
+      -dname "CN=Android Debug,O=Android,C=US"
+}
+
+# Sign
+& "$buildTools\apksigner.bat" sign `
+  --ks $debugKs --ks-key-alias androiddebugkey `
+  --ks-pass pass:android --key-pass pass:android `
+  --out app-signed.apk app-universal-release-unsigned.apk
+
+# Install on connected device
+adb install -r app-signed.apk
+```
+
+### Production signing (for Play Store)
+
+```powershell
+# Generate a release keystore (do this once, keep it safe)
+keytool -genkey -v -keystore nostr-vpn-release.jks -alias nostr-vpn `
+  -keyalg RSA -keysize 2048 -validity 10000
+
+# Sign with release key
+& "$buildTools\apksigner.bat" sign `
+  --ks nostr-vpn-release.jks --ks-key-alias nostr-vpn `
+  --out app-release-signed.apk app-universal-release-unsigned.apk
+```
+
+---
+
+## Automated scripts
+
+Two PowerShell scripts are provided in `scripts/` for convenience:
+
+- **`build_android_windows.ps1`** — Sets up environment and runs the full build
+- **`sign_and_install_android.ps1`** — Signs the APK and installs it on a connected device
+
+Edit the paths at the top of each script to match your system, then run:
+
+```powershell
+.\scripts\build_android_windows.ps1
+.\scripts\sign_and_install_android.ps1
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `linker cc not found` for android target | Missing NDK linker config | Tauri handles this automatically via `NDK_HOME`. Make sure the env var is set. |
+| `Unable to find OpenSSL` | openssl-sys can't find Android OpenSSL | The project uses `rustls` — ensure no dependency pulls in `openssl-sys`. |
+| APK won't install ("not signed") | Android rejects unsigned APKs | Sign with `apksigner` (see above). |
+| `JAVA_HOME` not recognized | JDK path wrong or not set | Verify `java -version` prints 17.x with the correct `JAVA_HOME`. |
+| Gradle fails with "SDK not found" | `ANDROID_HOME` not set | Set both `ANDROID_HOME` and `ANDROID_SDK_ROOT`. |
+| `ring` build failure | Old `ring` version incompatible with NDK r28 | Update `ring` to 0.17+ or use a `[patch]` in Cargo.toml. |
+
+---
+
+## Architecture reference
+
+The built APK contains:
+
+```
+APK
+├── lib/arm64-v8a/libnostr_vpn_gui_lib.so   ← Core Rust (Nostr signaling + WireGuard via boringtun)
+├── assets/                                   ← Frontend Svelte (HTML/JS/CSS via Vite)
+└── classes.dex                               ← Kotlin (VpnService + Tauri plugin bridge)
+```
+
+Runtime flow:
+
+```
+UI (Svelte/WebView)
+  → Tauri invoke (JS → Rust)
+  → android_session.rs (Nostr signaling, peer management)
+  → android_vpn.rs (Tauri plugin bridge to Kotlin)
+  → NostrVpnPlugin.kt (prepare/start/stop/status)
+  → NostrVpnService.kt (Android VpnService, TUN fd)
+  → mobile_wg.rs (boringtun userspace WireGuard)
+  → Android OS TUN driver
+```

--- a/scripts/build_android_windows.ps1
+++ b/scripts/build_android_windows.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    Build nostr-vpn Android APK on Windows.
+
+.DESCRIPTION
+    Sets up environment variables and runs the Tauri Android build.
+    Edit the paths below to match your system before running.
+
+.EXAMPLE
+    .\scripts\build_android_windows.ps1
+    .\scripts\build_android_windows.ps1 -Target x86_64 -Debug
+#>
+
+param(
+    [ValidateSet("aarch64", "armv7", "x86_64", "i686")]
+    [string]$Target = "aarch64",
+
+    [switch]$Debug
+)
+
+$ErrorActionPreference = "Continue"
+
+# ──────────────────────────────────────────────
+# CONFIGURATION — Edit these paths for your system
+# ──────────────────────────────────────────────
+
+$JavaHome   = "C:\Program Files\Eclipse Adoptium\jdk-17.0.18.8-hotspot"
+$SdkRoot    = "$env:LOCALAPPDATA\Android\Sdk"
+
+# Auto-detect NDK version (picks the latest installed)
+$NdkBase = Join-Path $SdkRoot "ndk"
+if (Test-Path $NdkBase) {
+    $NdkVersion = Get-ChildItem $NdkBase -Directory | Sort-Object Name -Descending | Select-Object -First 1
+    $NdkHome = $NdkVersion.FullName
+} else {
+    Write-Error "No NDK found in $NdkBase. Install via: sdkmanager --install 'ndk;28.2.13676358'"
+    exit 1
+}
+
+# ──────────────────────────────────────────────
+# ENVIRONMENT
+# ──────────────────────────────────────────────
+
+$env:JAVA_HOME        = $JavaHome
+$env:ANDROID_HOME     = $SdkRoot
+$env:ANDROID_SDK_ROOT = $SdkRoot
+$env:NDK_HOME         = $NdkHome
+$env:ANDROID_NDK_HOME = $NdkHome
+$env:PATH             = "$JavaHome\bin;C:\Program Files\nodejs;$env:APPDATA\npm;$env:PATH"
+
+# ──────────────────────────────────────────────
+# PREFLIGHT CHECKS
+# ──────────────────────────────────────────────
+
+Write-Host "`n=== Preflight checks ===" -ForegroundColor Cyan
+
+$checks = @(
+    @{ Name = "Rust";    Cmd = "rustc --version" },
+    @{ Name = "Cargo";   Cmd = "cargo --version" },
+    @{ Name = "Java";    Cmd = "java -version 2>&1 | Select-Object -First 1" },
+    @{ Name = "Node";    Cmd = "node --version" },
+    @{ Name = "pnpm";    Cmd = "pnpm --version" }
+)
+
+$failed = $false
+foreach ($c in $checks) {
+    try {
+        $result = Invoke-Expression $c.Cmd 2>&1 | Select-Object -First 1
+        Write-Host "  [OK] $($c.Name): $result" -ForegroundColor Green
+    } catch {
+        Write-Host "  [FAIL] $($c.Name): not found" -ForegroundColor Red
+        $failed = $true
+    }
+}
+
+# Check Android targets
+$targets = rustup target list --installed 2>&1
+if ($targets -notmatch "aarch64-linux-android") {
+    Write-Host "  [FAIL] Rust Android targets not installed" -ForegroundColor Red
+    Write-Host "         Run: rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android" -ForegroundColor Yellow
+    $failed = $true
+} else {
+    Write-Host "  [OK] Rust Android targets installed" -ForegroundColor Green
+}
+
+if (-not (Test-Path $NdkHome)) {
+    Write-Host "  [FAIL] NDK not found at $NdkHome" -ForegroundColor Red
+    $failed = $true
+} else {
+    Write-Host "  [OK] NDK: $NdkHome" -ForegroundColor Green
+}
+
+if ($failed) {
+    Write-Host "`nFix the issues above before building. See docs/android-build-windows.md" -ForegroundColor Red
+    exit 1
+}
+
+# ──────────────────────────────────────────────
+# FIND PROJECT ROOT
+# ──────────────────────────────────────────────
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+
+if (-not (Test-Path (Join-Path $ProjectRoot "Cargo.toml"))) {
+    Write-Error "Cannot find project root. Run this script from the repo's scripts/ directory."
+    exit 1
+}
+
+Set-Location $ProjectRoot
+
+# ──────────────────────────────────────────────
+# INSTALL FRONTEND DEPENDENCIES
+# ──────────────────────────────────────────────
+
+Write-Host "`n=== Installing frontend dependencies ===" -ForegroundColor Cyan
+pnpm --dir crates/nostr-vpn-gui install --frozen-lockfile
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "pnpm install failed."
+    exit 1
+}
+
+# ──────────────────────────────────────────────
+# BUILD
+# ──────────────────────────────────────────────
+
+$buildArgs = @("--dir", "crates/nostr-vpn-gui", "exec", "tauri", "android", "build", "--target", $Target, "--apk")
+
+if ($Debug) {
+    $buildArgs += "--debug"
+    Write-Host "`n=== Building DEBUG APK (target: $Target) ===" -ForegroundColor Cyan
+} else {
+    $buildArgs += "--ci"
+    Write-Host "`n=== Building RELEASE APK (target: $Target) ===" -ForegroundColor Cyan
+}
+
+& pnpm @buildArgs
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Build failed. Check the output above for errors."
+    exit 1
+}
+
+# ──────────────────────────────────────────────
+# LOCATE OUTPUT
+# ──────────────────────────────────────────────
+
+$apkDir = Join-Path $ProjectRoot "crates\nostr-vpn-gui\src-tauri\gen\android\app\build\outputs\apk"
+$apks = Get-ChildItem -Path $apkDir -Recurse -Filter "*.apk" -ErrorAction SilentlyContinue
+
+Write-Host "`n=== Build complete ===" -ForegroundColor Green
+if ($apks) {
+    foreach ($apk in $apks) {
+        $sizeMB = [math]::Round($apk.Length / 1MB, 1)
+        Write-Host "  $($apk.FullName) ($sizeMB MB)" -ForegroundColor White
+    }
+} else {
+    Write-Host "  APK not found — check build output for errors." -ForegroundColor Yellow
+}
+
+Write-Host "`nTo sign and install, run: .\scripts\sign_and_install_android.ps1" -ForegroundColor Cyan

--- a/scripts/sign_and_install_android.ps1
+++ b/scripts/sign_and_install_android.ps1
@@ -1,0 +1,156 @@
+<#
+.SYNOPSIS
+    Sign and install a nostr-vpn Android APK on a connected device.
+
+.DESCRIPTION
+    Signs the release APK with a debug or release keystore and installs it
+    via adb on a connected Android device.
+
+.EXAMPLE
+    .\scripts\sign_and_install_android.ps1
+    .\scripts\sign_and_install_android.ps1 -Release -Keystore .\my-release.jks -KeyAlias mykey
+#>
+
+param(
+    [switch]$Release,
+
+    [string]$Keystore,
+
+    [string]$KeyAlias,
+
+    [switch]$SkipInstall
+)
+
+$ErrorActionPreference = "Continue"
+
+# ──────────────────────────────────────────────
+# CONFIGURATION
+# ──────────────────────────────────────────────
+
+$JavaHome   = "C:\Program Files\Eclipse Adoptium\jdk-17.0.18.8-hotspot"
+$SdkRoot    = "$env:LOCALAPPDATA\Android\Sdk"
+
+$env:JAVA_HOME = $JavaHome
+$env:PATH      = "$JavaHome\bin;$env:PATH"
+
+# Auto-detect build-tools version
+$btBase = Join-Path $SdkRoot "build-tools"
+$btVersion = Get-ChildItem $btBase -Directory -ErrorAction SilentlyContinue |
+    Sort-Object Name -Descending | Select-Object -First 1
+if (-not $btVersion) {
+    Write-Error "No build-tools found in $btBase"
+    exit 1
+}
+$apkSignerPath = Join-Path $btVersion.FullName "apksigner.bat"
+
+$adbPath = Join-Path $SdkRoot "platform-tools\adb.exe"
+
+# ──────────────────────────────────────────────
+# FIND APK
+# ──────────────────────────────────────────────
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$apkDir = Join-Path $ProjectRoot "crates\nostr-vpn-gui\src-tauri\gen\android\app\build\outputs\apk"
+
+$unsignedApk = Get-ChildItem -Path $apkDir -Recurse -Filter "*unsigned*" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+if (-not $unsignedApk) {
+    # Fall back to any release APK
+    $unsignedApk = Get-ChildItem -Path $apkDir -Recurse -Filter "*release*.apk" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
+
+if (-not $unsignedApk) {
+    Write-Error "No APK found. Run build_android_windows.ps1 first."
+    exit 1
+}
+
+Write-Host "Found APK: $($unsignedApk.FullName)" -ForegroundColor Cyan
+
+$signedApk = Join-Path $unsignedApk.DirectoryName "app-signed.apk"
+
+# ──────────────────────────────────────────────
+# KEYSTORE
+# ──────────────────────────────────────────────
+
+if ($Release) {
+    if (-not $Keystore) {
+        Write-Error "Release signing requires -Keystore path."
+        exit 1
+    }
+    if (-not $KeyAlias) {
+        Write-Error "Release signing requires -KeyAlias."
+        exit 1
+    }
+    $ksPath  = $Keystore
+    $ksAlias = $KeyAlias
+    # Prompt for passwords interactively
+    $ksPass  = Read-Host "Keystore password" -AsSecureString
+    $keyPass = Read-Host "Key password" -AsSecureString
+    $ksPassPlain  = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ksPass))
+    $keyPassPlain = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($keyPass))
+
+    Write-Host "`n=== Signing with RELEASE keystore ===" -ForegroundColor Yellow
+    & $apkSignerPath sign `
+        --ks $ksPath --ks-key-alias $ksAlias `
+        --ks-pass "pass:$ksPassPlain" --key-pass "pass:$keyPassPlain" `
+        --out $signedApk $unsignedApk.FullName
+} else {
+    $debugKs = Join-Path $env:USERPROFILE ".android\debug.keystore"
+
+    # Generate debug keystore if needed
+    if (-not (Test-Path $debugKs)) {
+        Write-Host "Generating debug keystore at $debugKs" -ForegroundColor Yellow
+        $debugDir = Split-Path $debugKs
+        if (-not (Test-Path $debugDir)) { New-Item -ItemType Directory -Path $debugDir -Force | Out-Null }
+
+        keytool -genkey -v -keystore $debugKs -storepass android -alias androiddebugkey `
+            -keypass android -keyalg RSA -keysize 2048 -validity 10000 `
+            -dname "CN=Android Debug,O=Android,C=US"
+    }
+
+    Write-Host "`n=== Signing with DEBUG keystore ===" -ForegroundColor Cyan
+    & $apkSignerPath sign `
+        --ks $debugKs --ks-key-alias androiddebugkey `
+        --ks-pass pass:android --key-pass pass:android `
+        --out $signedApk $unsignedApk.FullName
+}
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Signing failed."
+    exit 1
+}
+
+$sizeMB = [math]::Round((Get-Item $signedApk).Length / 1MB, 1)
+Write-Host "Signed APK: $signedApk ($sizeMB MB)" -ForegroundColor Green
+
+# ──────────────────────────────────────────────
+# INSTALL
+# ──────────────────────────────────────────────
+
+if ($SkipInstall) {
+    Write-Host "`nSkipping install (-SkipInstall). APK ready at: $signedApk" -ForegroundColor Cyan
+    exit 0
+}
+
+# Check for connected device
+$devices = & $adbPath devices 2>&1
+$connected = ($devices | Select-String "device$" | Measure-Object).Count
+
+if ($connected -eq 0) {
+    Write-Host "`nNo Android device connected. Connect via USB and enable USB debugging." -ForegroundColor Yellow
+    Write-Host "APK ready at: $signedApk" -ForegroundColor Cyan
+    exit 0
+}
+
+Write-Host "`n=== Installing on device ===" -ForegroundColor Cyan
+& $adbPath install -r $signedApk
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "`nInstalled successfully!" -ForegroundColor Green
+} else {
+    Write-Host "`nInstall failed. Try: adb uninstall <package-name> first, then retry." -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
**Description :**
```
## What
Adds documentation and automation scripts for building the Android APK on Windows.

## Why
The Android port is fully implemented in the codebase but build steps only cover CI (Ubuntu). This adds Windows-specific guidance for contributors.

## Included
- `docs/android-build-windows.md` — Complete setup guide: prerequisites, build, signing, install, troubleshooting
- `scripts/build_android_windows.ps1` — Automated build with preflight checks and NDK auto-detection
- `scripts/sign_and_install_android.ps1` — Debug/release signing + adb install
- `README.md` — New "Build for Android (Windows)" section

## Tested on
- Windows 11, Rust 1.93.1, NDK r28c, JDK 17 (Temurin), Node 24, Tauri CLI 2.10
- APK built, signed, installed and VPN operational on physical device