### PR TITLE
Allow network_id to be a Namecoin name with chain-verified admins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,15 +2591,18 @@ dependencies = [
  "hostname",
  "netdev",
  "nostr-sdk 0.35.0",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ socket2 = "0.6"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.28"
+tokio-rustls = { version = "0.26", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
+webpki-roots = "0.26"
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/nostr-vpn-app-core/src/mobile_tunnel.rs
+++ b/crates/nostr-vpn-app-core/src/mobile_tunnel.rs
@@ -1010,7 +1010,8 @@ async fn apply_mobile_roster_frame(
         source_pubkey,
         network_id,
         roster,
-    )?
+    )
+    .await?
     else {
         return Ok(());
     };
@@ -1119,7 +1120,7 @@ fn control_frame_source_pubkey(
     })
 }
 
-fn apply_mobile_roster(
+async fn apply_mobile_roster(
     app_config: &Arc<RwLock<AppConfig>>,
     app_config_dirty: &AtomicBool,
     config_path: Option<&Path>,
@@ -1127,11 +1128,39 @@ fn apply_mobile_roster(
     network_id: &str,
     roster: &NetworkRoster,
 ) -> Result<Option<MobileTunnelConfig>> {
+    let chain = if let Some(id) =
+        nostr_vpn_core::namecoin_name_verify::parse_namecoin_network_id(network_id)
+    {
+        match nostr_vpn_core::namecoin_name_verify::resolve_network_record(&id).await {
+            Ok(record) => Some(record),
+            Err(error) => {
+                mobile_debug_log(format!(
+                    "mobile: refusing roster update for chain-anchored {} ({error:#})",
+                    id.display()
+                ));
+                let mut app = app_config
+                    .write()
+                    .map_err(|_| anyhow!("mobile app config lock poisoned"))?;
+                app.quarantine_network(
+                    network_id,
+                    &format!("chain anchor {} unreachable: {error}", id.display()),
+                );
+                if let Some(config_path) = config_path {
+                    let _ = app.save(config_path);
+                }
+                app_config_dirty.store(true, Ordering::Relaxed);
+                return Ok(None);
+            }
+        }
+    } else {
+        None
+    };
+
     let mut app = app_config
         .write()
         .map_err(|_| anyhow!("mobile app config lock poisoned"))?;
     app.ensure_defaults();
-    let changed = app.apply_admin_signed_shared_roster(
+    let changed = app.apply_admin_signed_shared_roster_with_chain(
         network_id,
         &roster.network_name,
         roster.participants.clone(),
@@ -1139,8 +1168,21 @@ fn apply_mobile_roster(
         roster.aliases.clone(),
         roster.signed_at,
         sender_pubkey,
+        chain.as_ref(),
     )?;
     if !changed {
+        if let Some(network) = app.network_by_id(network_id)
+            && !network.chain_quarantine_reason.is_empty()
+        {
+            mobile_debug_log(format!(
+                "mobile: roster update ignored, network {network_id} is quarantined ({})",
+                network.chain_quarantine_reason
+            ));
+            if let Some(config_path) = config_path {
+                let _ = app.save(config_path);
+            }
+            app_config_dirty.store(true, Ordering::Relaxed);
+        }
         return Ok(None);
     }
     maybe_autoconfigure_node(&mut app);
@@ -2176,6 +2218,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         app.exit_node = peer.to_string();
 
@@ -2222,6 +2265,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         app.fips_peer_endpoints
             .insert(peer.to_string(), vec!["192.168.50.10:51820".to_string()]);
@@ -2265,6 +2309,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         app.fips_peer_endpoints
             .insert(admin.clone(), vec!["192.168.50.10:51820".to_string()]);
@@ -2319,6 +2364,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         app.ensure_defaults();
 
@@ -2430,6 +2476,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         let requester = Keys::generate().public_key().to_hex();
         let app_config = Arc::new(RwLock::new(app));
@@ -2528,6 +2575,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         admin_app.ensure_defaults();
         admin_app
@@ -2752,6 +2800,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         let config = MobileTunnelConfig::from_app(&app).expect("mobile config");
         let mesh = FipsMeshRuntime::with_local_routes(config.peers.clone(), vec![]);
@@ -2804,6 +2853,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         let config = MobileTunnelConfig::from_app(&app).expect("mobile config");
         let mesh = FipsMeshRuntime::with_local_routes(config.peers.clone(), vec![]);
@@ -2880,6 +2930,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         }];
         app.wireguard_exit = WireGuardExitConfig {
             enabled: true,

--- a/crates/nostr-vpn-cli/src/main.rs
+++ b/crates/nostr-vpn-cli/src/main.rs
@@ -242,6 +242,10 @@ enum Command {
     CreateInvite(CreateInviteArgs),
     /// Import an `nvpn://invite/...` code into the active network config.
     ImportInvite(ImportInviteArgs),
+    /// Verify a Namecoin-anchored network id against its chain record. Use
+    /// this to sanity-check that the local admin list still matches the
+    /// chain anchor (typically the active network's `network_id`).
+    VerifyNetworkName(VerifyNetworkNameArgs),
     /// Broadcast the active network's invite over LAN multicast so nearby
     /// devices running `nvpn discover` can pair without copy/pasting a code.
     /// Runs in the foreground; Ctrl-C stops broadcasting.
@@ -609,6 +613,22 @@ struct ImportInviteArgs {
     invite: String,
     #[arg(long)]
     json: bool,
+    /// Bypass Namecoin (`.bit`/`d/`) chain admin verification. Only for
+    /// testing against networks whose admin list is not anchored on chain
+    /// yet; production imports should leave this off.
+    #[arg(long)]
+    insecure_skip_name_verify: bool,
+}
+
+#[derive(Debug, Args)]
+struct VerifyNetworkNameArgs {
+    #[arg(long)]
+    config: Option<PathBuf>,
+    /// Network id to verify. Defaults to the active network's id.
+    #[arg(long)]
+    network_id: Option<String>,
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -878,6 +898,8 @@ async fn run_command(command: Command) -> Result<()> {
                     (peers, expected, 0, false, "config")
                 };
 
+            let network_anchor = network_anchor_status(&app, &network_id);
+
             if args.json {
                 let endpoint = status_endpoint(&app, &daemon);
                 let listen_port = status_listen_port(&app, &daemon);
@@ -886,6 +908,7 @@ async fn run_command(command: Command) -> Result<()> {
                     serde_json::to_string_pretty(&json!({
                         "status_source": status_source,
                         "network_id": network_id,
+                        "network_anchor": network_anchor,
                         "magic_dns_suffix": app.magic_dns_suffix,
                         "autoconnect": app.autoconnect,
                         "node_id": app.node.id,
@@ -915,6 +938,9 @@ async fn run_command(command: Command) -> Result<()> {
                 let endpoint = status_endpoint(&app, &daemon);
                 let listen_port = status_listen_port(&app, &daemon);
                 println!("network: {network_id}");
+                if let Some(anchor) = &network_anchor {
+                    println!("network_anchor: {anchor}");
+                }
                 println!("magic_dns_suffix: {}", app.magic_dns_suffix);
                 println!("autoconnect: {}", app.autoconnect);
                 println!("node: {}", app.node.id);
@@ -1139,6 +1165,10 @@ async fn run_command(command: Command) -> Result<()> {
             let config_path = args.config.unwrap_or_else(default_config_path);
             let mut app = load_or_default_config(&config_path)?;
             let invite = parse_network_invite(&args.invite)?;
+
+            let verification_status =
+                verify_invite_against_namecoin(&invite, args.insecure_skip_name_verify).await?;
+
             apply_network_invite_to_active_network(&mut app, &invite)?;
             let join_request_queued = queue_active_network_join_request(&mut app)?;
             app.ensure_defaults();
@@ -1147,13 +1177,31 @@ async fn run_command(command: Command) -> Result<()> {
             maybe_reload_running_daemon(&config_path);
 
             if args.json {
-                println!("{}", serde_json::to_string_pretty(&app)?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "saved": config_path.display().to_string(),
+                        "network_id": app.effective_network_id(),
+                        "invite_imported": app.active_network().name,
+                        "join_request_queued": join_request_queued,
+                        "namecoin_verification": verification_status,
+                    }))?
+                );
             } else {
                 println!("saved {}", config_path.display());
                 println!("network_id={}", app.effective_network_id());
                 println!("invite_imported={}", app.active_network().name);
                 println!("join_request_queued={join_request_queued}");
+                println!("namecoin_verification={}", verification_status);
             }
+        }
+        Command::VerifyNetworkName(args) => {
+            let config_path = args.config.unwrap_or_else(default_config_path);
+            let app = load_or_default_config(&config_path)?;
+            let network_id = args
+                .network_id
+                .unwrap_or_else(|| app.effective_network_id());
+            run_verify_network_name(&app, &network_id, args.json).await?;
         }
         Command::InviteBroadcast(args) => {
             run_invite_broadcast(args)?;
@@ -2540,7 +2588,7 @@ fn persist_inbound_join_request(
     }
 }
 
-fn persist_shared_network_roster(
+async fn persist_shared_network_roster(
     app: &mut AppConfig,
     config_path: &Path,
     sender_pubkey: &str,
@@ -2548,7 +2596,30 @@ fn persist_shared_network_roster(
     roster: &NetworkRoster,
     vpn_status: &mut String,
 ) -> Result<Option<String>> {
-    let changed = app.apply_admin_signed_shared_roster(
+    // For Namecoin-anchored networks, fetch the chain admin set up front so
+    // the apply step can refuse mismatched updates (and quarantine the
+    // network) without ever touching the on-disk roster.
+    let chain = if let Some(id) =
+        nostr_vpn_core::namecoin_name_verify::parse_namecoin_network_id(network_id)
+    {
+        match nostr_vpn_core::namecoin_name_verify::resolve_network_record(&id).await {
+            Ok(record) => Some(record),
+            Err(error) => {
+                let reason = format!(
+                    "chain anchor {} could not be resolved: {error}",
+                    id.display()
+                );
+                app.quarantine_network(network_id, &reason);
+                let _ = app.save(config_path);
+                *vpn_status = format!("Roster update for {} ignored: {reason}", id.display());
+                return Ok(None);
+            }
+        }
+    } else {
+        None
+    };
+
+    let changed = app.apply_admin_signed_shared_roster_with_chain(
         network_id,
         &roster.network_name,
         roster.participants.clone(),
@@ -2556,8 +2627,16 @@ fn persist_shared_network_roster(
         roster.aliases.clone(),
         roster.signed_at,
         sender_pubkey,
+        chain.as_ref(),
     )?;
     if !changed {
+        if let Some(network) = app.network_by_id(network_id)
+            && !network.chain_quarantine_reason.is_empty()
+        {
+            let reason = network.chain_quarantine_reason.clone();
+            let _ = app.save(config_path);
+            *vpn_status = format!("Network {network_id} quarantined: {reason}");
+        }
         return Ok(None);
     }
 
@@ -2577,7 +2656,7 @@ fn persist_shared_network_roster(
 }
 
 #[cfg(feature = "embedded-fips")]
-fn drain_fips_mesh_events(
+async fn drain_fips_mesh_events(
     runtime: &mut crate::fips_private_mesh::FipsPrivateTunnelRuntime,
     app: &mut AppConfig,
     config_path: &Path,
@@ -2621,7 +2700,9 @@ fn drain_fips_mesh_events(
                 &network_id,
                 &roster,
                 vpn_status,
-            ) {
+            )
+            .await
+            {
                 Ok(Some(_)) => roster_changed = true,
                 Ok(None) => {}
                 Err(error) => {
@@ -3582,6 +3663,185 @@ fn daemon_status_json_value(status: &DaemonStatus) -> serde_json::Value {
         "state_file": status.state_file,
         "state": visible_daemon_state_for_status(status.running, status.state.as_ref()),
     })
+}
+
+/// Result code for the Namecoin verification step printed by `import-invite`
+/// and `verify-network-name`. Stored as a string in JSON output for stable
+/// scripting consumption.
+fn namecoin_status_string(
+    verdict: &nostr_vpn_core::namecoin_name_verify::NamecoinNetworkId,
+    skipped: bool,
+) -> String {
+    if skipped {
+        format!("skipped (insecure) {}", verdict.display())
+    } else {
+        format!("verified {}", verdict.display())
+    }
+}
+
+/// Verify the invite's admin list against the chain anchor when the invite's
+/// `network_id` is a Namecoin name. Returns a status string suitable for the
+/// status output (`"verified d/acmevpn"`, `"skipped (insecure) d/acmevpn"`,
+/// or `"not-namecoin-anchored"`).
+async fn verify_invite_against_namecoin(
+    invite: &nostr_vpn_core::invite::NetworkInvite,
+    insecure_skip: bool,
+) -> Result<String> {
+    let Some(id) =
+        nostr_vpn_core::namecoin_name_verify::parse_namecoin_network_id(&invite.network_id)
+    else {
+        return Ok("not-namecoin-anchored".to_string());
+    };
+
+    if insecure_skip {
+        eprintln!(
+            "warning: --insecure-skip-name-verify bypasses chain admin verification for {}",
+            id.display()
+        );
+        return Ok(namecoin_status_string(&id, true));
+    }
+
+    let chain = nostr_vpn_core::namecoin_name_verify::resolve_network_record(&id)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to resolve Namecoin anchor {}; re-run with --insecure-skip-name-verify only if you trust the invite out-of-band",
+                id.display()
+            )
+        })?;
+
+    let invite_admin_hex = invite
+        .admins
+        .iter()
+        .map(|admin| nostr_vpn_core::namecoin_name_verify::canonicalize_admin_hex(admin))
+        .collect::<Result<Vec<_>>>()
+        .context("normalising invite admin pubkeys")?;
+
+    nostr_vpn_core::namecoin_name_verify::verify_admins_against_chain(&invite_admin_hex, &chain)
+        .with_context(|| {
+            format!(
+                "invite admin set does not match chain anchor {}; refusing import",
+                id.display()
+            )
+        })?;
+
+    Ok(namecoin_status_string(&id, false))
+}
+
+async fn run_verify_network_name(app: &AppConfig, network_id: &str, json: bool) -> Result<()> {
+    let Some(id) = nostr_vpn_core::namecoin_name_verify::parse_namecoin_network_id(network_id)
+    else {
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "network_id": network_id,
+                    "verdict": "not-namecoin-anchored",
+                }))?
+            );
+        } else {
+            println!("network_id={network_id}");
+            println!("verdict: not-namecoin-anchored");
+        }
+        return Ok(());
+    };
+
+    let local_admins = app
+        .network_admin_pubkeys_hex(network_id)
+        .unwrap_or_default();
+    let local_admins_canonical = local_admins
+        .iter()
+        .filter_map(|admin| {
+            nostr_vpn_core::namecoin_name_verify::canonicalize_admin_hex(admin).ok()
+        })
+        .collect::<Vec<_>>();
+
+    let chain = match nostr_vpn_core::namecoin_name_verify::resolve_network_record(&id).await {
+        Ok(chain) => chain,
+        Err(error) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "network_id": id.display(),
+                        "verdict": "resolve-error",
+                        "error": error.to_string(),
+                        "local_admins": local_admins_canonical,
+                    }))?
+                );
+            } else {
+                println!("network_id={}", id.display());
+                println!("verdict: resolve-error");
+                println!("error: {error:#}");
+                if !local_admins_canonical.is_empty() {
+                    println!("local_admins:");
+                    for admin in &local_admins_canonical {
+                        println!("  {admin}");
+                    }
+                }
+            }
+            return Ok(());
+        }
+    };
+
+    let verdict = nostr_vpn_core::namecoin_name_verify::verify_admins_against_chain(
+        &local_admins_canonical,
+        &chain,
+    );
+
+    if json {
+        let verdict_string = match &verdict {
+            Ok(()) => "ok".to_string(),
+            Err(error) => format!("mismatch: {error}"),
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "network_id": id.display(),
+                "chain_network_name": chain.network_name_hint,
+                "chain_admins": chain.admins,
+                "local_admins": local_admins_canonical,
+                "verdict": verdict_string,
+            }))?
+        );
+    } else {
+        println!("network_id={}", id.display());
+        if let Some(name) = &chain.network_name_hint {
+            println!("chain_network_name: {name}");
+        }
+        println!("chain_admins:");
+        for admin in &chain.admins {
+            println!("  {admin}");
+        }
+        println!("local_admins:");
+        for admin in &local_admins_canonical {
+            println!("  {admin}");
+        }
+        match &verdict {
+            Ok(()) => println!("verdict: ok"),
+            Err(error) => println!("verdict: mismatch ({error})"),
+        }
+    }
+
+    Ok(())
+}
+
+/// Format the network anchor line surfaced by `nvpn status`. Returns `None`
+/// for ordinary (non-Namecoin) network ids.
+fn network_anchor_status(app: &AppConfig, network_id: &str) -> Option<String> {
+    let parsed = nostr_vpn_core::namecoin_name_verify::parse_namecoin_network_id(network_id)?;
+    let quarantine = app
+        .network_by_id(network_id)
+        .map(|network| network.chain_quarantine_reason.clone())
+        .unwrap_or_default();
+    if quarantine.is_empty() {
+        Some(format!("{} \u{2713} verified-on-import", parsed.display()))
+    } else {
+        Some(format!(
+            "{} \u{2717} quarantined ({quarantine})",
+            parsed.display()
+        ))
+    }
 }
 
 fn status_endpoint(app: &AppConfig, daemon: &DaemonStatus) -> String {

--- a/crates/nostr-vpn-cli/src/session_runtime.rs
+++ b/crates/nostr-vpn-cli/src/session_runtime.rs
@@ -848,7 +848,9 @@ pub(crate) async fn daemon_vpn(args: DaemonArgs) -> Result<()> {
                         &mut app,
                         &config_path,
                         &mut vpn_status,
-                    ) {
+                    )
+                    .await
+                    {
                         Ok(true) => {
                             let reload = build_daemon_reload_config(
                                 app.clone(),

--- a/crates/nostr-vpn-cli/src/tests/config_cache.rs
+++ b/crates/nostr-vpn-cli/src/tests/config_cache.rs
@@ -25,6 +25,7 @@ fn participants_override_targets_the_active_network() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         },
         NetworkConfig {
             id: "work".to_string(),
@@ -39,6 +40,7 @@ fn participants_override_targets_the_active_network() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         },
     ];
     config.ensure_defaults();
@@ -331,6 +333,7 @@ fn config_overrides_set_the_active_network_mesh_id() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         },
         NetworkConfig {
             id: "work".to_string(),
@@ -345,6 +348,7 @@ fn config_overrides_set_the_active_network_mesh_id() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         },
     ];
     config.ensure_defaults();

--- a/crates/nostr-vpn-core/Cargo.toml
+++ b/crates/nostr-vpn-core/Cargo.toml
@@ -30,5 +30,8 @@ hickory-proto.workspace = true
 hostname.workspace = true
 netdev.workspace = true
 socket2.workspace = true
+tokio-rustls.workspace = true
+rustls.workspace = true
+webpki-roots.workspace = true
 
 [dev-dependencies]

--- a/crates/nostr-vpn-core/src/config.rs
+++ b/crates/nostr-vpn-core/src/config.rs
@@ -598,6 +598,12 @@ pub struct NetworkConfig {
     pub shared_roster_updated_at: u64,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub shared_roster_signed_by: String,
+    /// Set when the chain-anchored admin set diverged from a local admin
+    /// update. Quarantined networks stop accepting roster updates and surface
+    /// loudly in status output; clear by resolving the chain mismatch and
+    /// calling [`AppConfig::clear_network_chain_quarantine`].
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub chain_quarantine_reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -654,6 +660,7 @@ impl Default for AppConfig {
                 inbound_join_requests: Vec::new(),
                 shared_roster_updated_at: 0,
                 shared_roster_signed_by: String::new(),
+                chain_quarantine_reason: String::new(),
             }],
             node_name: default_node_name(),
             lan_discovery_enabled: default_lan_discovery_enabled(),
@@ -1059,6 +1066,7 @@ impl AppConfig {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         });
         let _ = self.note_network_roster_local_change(&id);
         id
@@ -1593,6 +1601,91 @@ impl AppConfig {
         self.normalize_selected_exit_node();
         self.normalize_peer_aliases();
         Ok(true)
+    }
+
+    /// Apply an admin-signed roster, but first verify the proposed admin set
+    /// is a subset of the supplied chain anchor when the network is
+    /// Namecoin-anchored (`network_id` of the form `d/<name>`).
+    ///
+    /// When the chain record is `None` and the id IS Namecoin-anchored, this
+    /// method refuses to apply (caller failed to resolve the chain — fail
+    /// closed). When the id is NOT Namecoin-anchored, the chain record is
+    /// ignored. On mismatch the network is quarantined and the new roster is
+    /// NOT applied.
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_admin_signed_shared_roster_with_chain(
+        &mut self,
+        network_id: &str,
+        network_name: &str,
+        participants: Vec<String>,
+        admins: Vec<String>,
+        aliases: HashMap<String, String>,
+        signed_at: u64,
+        signed_by: &str,
+        chain: Option<&crate::namecoin_name_verify::ChainNetworkRecord>,
+    ) -> Result<bool> {
+        let namecoin_id = crate::namecoin_name_verify::parse_namecoin_network_id(network_id);
+
+        if let Some(namecoin_id) = namecoin_id.as_ref() {
+            let chain = chain.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "refusing to apply roster for chain-anchored network {} without a chain record",
+                    namecoin_id.display()
+                )
+            })?;
+            if let Err(error) =
+                crate::namecoin_name_verify::verify_admins_against_chain(&admins, chain)
+            {
+                let reason = format!(
+                    "admin set diverged from chain anchor {}: {error}",
+                    namecoin_id.display()
+                );
+                self.quarantine_network(network_id, &reason);
+                return Ok(false);
+            }
+        }
+
+        self.apply_admin_signed_shared_roster(
+            network_id,
+            network_name,
+            participants,
+            admins,
+            aliases,
+            signed_at,
+            signed_by,
+        )
+    }
+
+    /// Mark a network as quarantined. Idempotent; later calls overwrite the
+    /// reason but preserve the quarantine state. Returns `true` if a network
+    /// matched.
+    pub fn quarantine_network(&mut self, network_id: &str, reason: &str) -> bool {
+        let normalized = normalize_runtime_network_id(network_id);
+        let Some(network) = self
+            .networks
+            .iter_mut()
+            .find(|network| normalize_runtime_network_id(&network.network_id) == normalized)
+        else {
+            return false;
+        };
+        network.chain_quarantine_reason = reason.trim().to_string();
+        true
+    }
+
+    /// Clear the chain-quarantine state for a network (e.g. after an operator
+    /// has reconciled local admins against the chain by hand).
+    pub fn clear_network_chain_quarantine(&mut self, network_id: &str) -> bool {
+        let normalized = normalize_runtime_network_id(network_id);
+        let Some(network) = self
+            .networks
+            .iter_mut()
+            .find(|network| normalize_runtime_network_id(&network.network_id) == normalized)
+        else {
+            return false;
+        };
+        let was_set = !network.chain_quarantine_reason.is_empty();
+        network.chain_quarantine_reason.clear();
+        was_set
     }
 
     pub fn mesh_members_pubkeys(&self) -> Vec<String> {

--- a/crates/nostr-vpn-core/src/lib.rs
+++ b/crates/nostr-vpn-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod invite;
 pub mod join_requests;
 pub mod lan_pairing;
 pub mod magic_dns;
+pub mod namecoin_name_verify;
 mod network_roster;
 mod network_routes;
 pub mod paths;

--- a/crates/nostr-vpn-core/src/namecoin_name_verify.rs
+++ b/crates/nostr-vpn-core/src/namecoin_name_verify.rs
@@ -1,0 +1,593 @@
+// TODO: consolidate with the nostr-vpn-namecoin crate introduced in the
+// `feat/namecoin-resolver` PR once that lands. Scoped to network-id name
+// verification.
+//
+//! Optional Namecoin (`.bit`) anchor for `network_id`.
+//!
+//! A `network_id` of the form `acmevpn.bit` (or canonical `d/acmevpn`) is
+//! treated as a chain-anchored name. The corresponding Namecoin record holds a
+//! `nostr.admins` array of hex pubkeys that defines the legitimate admin set
+//! for the network. Joiners verify on invite import that the invite's admin
+//! list is a subset of the chain admin set; the daemon re-verifies on roster
+//! updates. If the chain says otherwise, we refuse the action and (for roster
+//! updates) quarantine the network instead of silently applying.
+//!
+//! Resolution is intentionally minimal: ElectrumX `blockchain.name.get` over
+//! TLS to a small list of public servers, JSON `value` parsing, and the
+//! ifa-0001 subdomain walk. The sibling `feat/namecoin-resolver` PR
+//! introduces a full-fat crate that will replace this module.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
+use nostr_sdk::prelude::PublicKey;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+use tokio_rustls::{TlsConnector, rustls};
+
+/// Hard upper bound for a single ElectrumX call (connect + request + reply).
+pub const NAMECOIN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default ElectrumX servers tried in order until one returns a record. Both
+/// support `blockchain.name.get` and listen on TLS port 50002.
+pub const DEFAULT_ELECTRUMX_SERVERS: &[(&str, u16)] = &[
+    ("electrum-nmc.le-space.de", 50002),
+    ("nmc.bitcoins.sk", 50002),
+];
+
+/// Maximum number of ifa-0001 subdomain hops to follow when resolving a name.
+pub const MAX_ALIAS_HOPS: u8 = 4;
+
+/// A canonical `d/<name>` Namecoin network id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamecoinNetworkId {
+    /// Lowercase canonical form, e.g. `d/acmevpn`.
+    pub canonical: String,
+    /// Optional dotted suffix labels (`d/acmevpn/foo/bar` becomes
+    /// `["foo", "bar"]` and resolved against the parent record's
+    /// ifa-0001 `map` chain).
+    pub subdomain_labels: Vec<String>,
+}
+
+impl NamecoinNetworkId {
+    /// Bare `d/<name>` form, without subdomain labels.
+    pub fn root_name(&self) -> &str {
+        &self.canonical
+    }
+
+    /// Human-friendly display of the canonical id, including any subdomain
+    /// labels.
+    pub fn display(&self) -> String {
+        if self.subdomain_labels.is_empty() {
+            self.canonical.clone()
+        } else {
+            format!("{}/{}", self.canonical, self.subdomain_labels.join("/"))
+        }
+    }
+}
+
+/// Parsed `nostr.admins` (and friends) from a Namecoin record.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainNetworkRecord {
+    /// Hex pubkeys (lowercase, 64 chars) parsed from the chain record's
+    /// `nostr.admins` array. May be empty if the record is missing the
+    /// field — callers MUST treat empty as "no admins published" and
+    /// refuse to verify against it.
+    pub admins: Vec<String>,
+    /// Optional `nostr.network_name` from the record. Surfaced for UI only.
+    pub network_name_hint: Option<String>,
+}
+
+impl ChainNetworkRecord {
+    /// Build a record straight from a parsed Namecoin `value` blob. Returns
+    /// `Ok(None)` if the field is missing or wrong shape (the caller decides
+    /// whether that should fail closed).
+    pub fn from_value(value: &Value) -> Result<Self> {
+        let nostr = value
+            .get("nostr")
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow!("record is missing the `nostr` object"))?;
+
+        let admins_value = nostr
+            .get("admins")
+            .ok_or_else(|| anyhow!("record `nostr.admins` is missing"))?;
+        let admins_array = admins_value
+            .as_array()
+            .ok_or_else(|| anyhow!("record `nostr.admins` is not an array"))?;
+        let admins = admins_array
+            .iter()
+            .map(|entry| {
+                entry
+                    .as_str()
+                    .ok_or_else(|| anyhow!("record `nostr.admins` entry is not a string"))
+                    .and_then(canonicalize_admin_hex)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let network_name_hint = nostr
+            .get("network_name")
+            .and_then(Value::as_str)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        Ok(Self {
+            admins,
+            network_name_hint,
+        })
+    }
+}
+
+/// Try to recognise `value` as a Namecoin-anchored network id. Returns `None`
+/// for ordinary opaque ids (which keep working unchanged).
+pub fn parse_namecoin_network_id(value: &str) -> Option<NamecoinNetworkId> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Accept both `acmevpn.bit` and `d/acmevpn` and `d/acmevpn/sub/labels`.
+    let (root_label, subdomain_labels) = if let Some(rest) = trimmed.strip_prefix("d/") {
+        let mut parts = rest.split('/');
+        let root = parts.next().unwrap_or("").trim();
+        let labels = parts
+            .map(|label| label.trim().to_string())
+            .filter(|label| !label.is_empty())
+            .collect::<Vec<_>>();
+        (root.to_string(), labels)
+    } else if let Some(root) = trimmed.strip_suffix(".bit") {
+        // ".bit" form does not natively carry subdomain labels.
+        (root.trim().to_string(), Vec::new())
+    } else {
+        return None;
+    };
+
+    if root_label.is_empty() {
+        return None;
+    }
+    if !is_valid_namecoin_label(&root_label) {
+        return None;
+    }
+    for label in &subdomain_labels {
+        if !is_valid_namecoin_label(label) {
+            return None;
+        }
+    }
+
+    let canonical = format!("d/{}", root_label.to_ascii_lowercase());
+    Some(NamecoinNetworkId {
+        canonical,
+        subdomain_labels: subdomain_labels
+            .into_iter()
+            .map(|label| label.to_ascii_lowercase())
+            .collect(),
+    })
+}
+
+fn is_valid_namecoin_label(label: &str) -> bool {
+    // Namecoin `d/` names are constrained to 1-63 chars of
+    // `[a-z0-9-]`, no leading/trailing dash. (See Namecoin doc/wiki.)
+    let bytes = label.as_bytes();
+    if bytes.is_empty() || bytes.len() > 63 {
+        return false;
+    }
+    if bytes[0] == b'-' || bytes[bytes.len() - 1] == b'-' {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+}
+
+/// Pluggable transport so we can mock the ElectrumX wire shape in tests
+/// without standing up real TLS sockets. Each call corresponds to a single
+/// `blockchain.name.get` request.
+#[async_trait]
+pub trait NamecoinTransport: Send + Sync {
+    /// Fetch the raw `value` blob for `name` (e.g. `"d/acmevpn"`). Returns
+    /// `Ok(None)` if the record is missing.
+    async fn fetch_name_value(&self, name: &str) -> Result<Option<Value>>;
+}
+
+/// Verify that every invite admin appears in the chain admin set. The chain
+/// is allowed to list extra admins not present in the invite.
+pub fn verify_admins_against_chain(
+    invite_admins: &[String],
+    chain: &ChainNetworkRecord,
+) -> Result<()> {
+    if invite_admins.is_empty() {
+        return Err(anyhow!(
+            "invite admin list is empty; refusing to anchor an empty admin set"
+        ));
+    }
+    if chain.admins.is_empty() {
+        return Err(anyhow!(
+            "chain record has no admins published (nostr.admins missing or empty); \
+             refusing to verify against an empty anchor"
+        ));
+    }
+
+    let normalized_chain = chain
+        .admins
+        .iter()
+        .map(|admin| canonicalize_admin_hex(admin))
+        .collect::<Result<Vec<_>>>()?;
+
+    for admin in invite_admins {
+        let normalized = canonicalize_admin_hex(admin)?;
+        if !normalized_chain.iter().any(|chain| chain == &normalized) {
+            return Err(anyhow!(
+                "invite admin {admin} is not in the chain admin set"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Normalize a pubkey (hex or npub bech32) to lowercase hex.
+pub fn canonicalize_admin_hex(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("admin pubkey is empty"));
+    }
+    let public_key = PublicKey::parse(trimmed)
+        .map_err(|error| anyhow!("invalid admin pubkey '{trimmed}': {error}"))?;
+    Ok(public_key.to_hex().to_ascii_lowercase())
+}
+
+/// Resolve a Namecoin-anchored network id using the supplied transport.
+///
+/// Performs an ifa-0001 subdomain walk when the id carries `d/<root>/<...>`
+/// labels. The walk follows the record's `map.<label>` chain (the convention
+/// from Namecoin Improvement Proposal 0001) until the labels are exhausted or
+/// a hop is missing.
+pub async fn resolve_with_transport(
+    transport: &dyn NamecoinTransport,
+    id: &NamecoinNetworkId,
+) -> Result<ChainNetworkRecord> {
+    let root_value = transport
+        .fetch_name_value(&id.canonical)
+        .await
+        .with_context(|| format!("fetching {} from chain", id.canonical))?
+        .ok_or_else(|| anyhow!("Namecoin record {} not found", id.canonical))?;
+
+    let mut current = root_value;
+    let mut hops = 0u8;
+    for label in &id.subdomain_labels {
+        if hops >= MAX_ALIAS_HOPS {
+            return Err(anyhow!(
+                "subdomain walk for {} exceeded {MAX_ALIAS_HOPS} hops",
+                id.display()
+            ));
+        }
+        hops = hops.saturating_add(1);
+
+        let next = current
+            .get("map")
+            .and_then(Value::as_object)
+            .and_then(|map| map.get(label))
+            .cloned();
+        let Some(next) = next else {
+            return Err(anyhow!(
+                "subdomain label {label} not present in {} ifa-0001 map",
+                id.canonical
+            ));
+        };
+        current = next;
+    }
+
+    ChainNetworkRecord::from_value(&current)
+}
+
+/// Resolve a Namecoin-anchored network id using the default TLS-backed
+/// transport against the public ElectrumX servers in
+/// [`DEFAULT_ELECTRUMX_SERVERS`]. Honours [`NAMECOIN_RESOLVE_TIMEOUT`].
+pub async fn resolve_network_record(id: &NamecoinNetworkId) -> Result<ChainNetworkRecord> {
+    let transport = ElectrumXTlsTransport::new(DEFAULT_ELECTRUMX_SERVERS.to_vec());
+    match timeout(
+        NAMECOIN_RESOLVE_TIMEOUT,
+        resolve_with_transport(&transport, id),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(anyhow!(
+            "Namecoin resolution timed out after {}s",
+            NAMECOIN_RESOLVE_TIMEOUT.as_secs()
+        )),
+    }
+}
+
+/// Real ElectrumX transport. Tries each server in order until one succeeds.
+pub struct ElectrumXTlsTransport {
+    servers: Vec<(&'static str, u16)>,
+}
+
+impl ElectrumXTlsTransport {
+    pub fn new(servers: Vec<(&'static str, u16)>) -> Self {
+        Self { servers }
+    }
+}
+
+#[async_trait]
+impl NamecoinTransport for ElectrumXTlsTransport {
+    async fn fetch_name_value(&self, name: &str) -> Result<Option<Value>> {
+        let mut last_error: Option<anyhow::Error> = None;
+        for (host, port) in &self.servers {
+            match electrumx_name_get_tls(host, *port, name).await {
+                Ok(Some(value)) => return Ok(Some(value)),
+                Ok(None) => return Ok(None),
+                Err(error) => {
+                    tracing::debug!(
+                        host,
+                        port,
+                        name,
+                        ?error,
+                        "namecoin resolver: server failed, trying next"
+                    );
+                    last_error = Some(error);
+                }
+            }
+        }
+        Err(last_error
+            .unwrap_or_else(|| anyhow!("no ElectrumX servers configured for namecoin resolver")))
+    }
+}
+
+async fn electrumx_name_get_tls(host: &str, port: u16, name: &str) -> Result<Option<Value>> {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let tcp = TcpStream::connect((host, port))
+        .await
+        .with_context(|| format!("connecting to ElectrumX server {host}:{port}"))?;
+    let server_name = rustls::pki_types::ServerName::try_from(host)
+        .map_err(|error| anyhow!("invalid ElectrumX host {host}: {error}"))?
+        .to_owned();
+    let mut tls = connector
+        .connect(server_name, tcp)
+        .await
+        .with_context(|| format!("TLS handshake with {host}:{port}"))?;
+
+    let request = serde_json::json!({
+        "id": 1,
+        "method": "blockchain.name.get",
+        "params": [name],
+    });
+    let mut payload = serde_json::to_vec(&request)?;
+    payload.push(b'\n');
+    tls.write_all(&payload).await?;
+    tls.flush().await?;
+
+    let mut reader = BufReader::new(tls);
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await?;
+    if n == 0 {
+        return Err(anyhow!("ElectrumX server closed connection before reply"));
+    }
+
+    let response: Value = serde_json::from_str(line.trim())
+        .with_context(|| format!("parsing ElectrumX reply from {host}:{port}"))?;
+
+    if let Some(error) = response.get("error")
+        && !error.is_null()
+    {
+        // ElectrumX returns an error object when the name is missing. Treat
+        // a -32600/"name not found" style error as "no record"; surface
+        // others as failures.
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let lc = message.to_ascii_lowercase();
+        if lc.contains("not found") || lc.contains("does not exist") {
+            return Ok(None);
+        }
+        return Err(anyhow!("ElectrumX returned error: {message}"));
+    }
+
+    let result = response
+        .get("result")
+        .ok_or_else(|| anyhow!("ElectrumX reply has no `result` field"))?;
+    if result.is_null() {
+        return Ok(None);
+    }
+    let value_str = result
+        .get("value")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("ElectrumX `result.value` is missing or not a string"))?;
+    let value: Value = serde_json::from_str(value_str.trim())
+        .with_context(|| format!("parsing record `value` for {name}"))?;
+    Ok(Some(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct StubTransport {
+        responses: Mutex<HashMap<String, Result<Option<Value>, String>>>,
+    }
+
+    impl StubTransport {
+        fn new(entries: Vec<(&str, Result<Option<Value>, String>)>) -> Self {
+            Self {
+                responses: Mutex::new(
+                    entries
+                        .into_iter()
+                        .map(|(name, value)| (name.to_string(), value))
+                        .collect(),
+                ),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl NamecoinTransport for StubTransport {
+        async fn fetch_name_value(&self, name: &str) -> Result<Option<Value>> {
+            let entry = self
+                .responses
+                .lock()
+                .unwrap()
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| Err(format!("no stub for {name}")));
+            entry.map_err(|message| anyhow!(message))
+        }
+    }
+
+    fn fake_admin(_byte: u8) -> String {
+        // Real secp256k1 keys; deterministic randomness isn't required for
+        // these tests because we only care about set membership.
+        use nostr_sdk::prelude::Keys;
+        Keys::generate().public_key().to_hex()
+    }
+
+    fn fake_record(admins: &[&str]) -> Value {
+        let array: Vec<Value> = admins
+            .iter()
+            .map(|a| Value::String((*a).to_string()))
+            .collect();
+        serde_json::json!({ "nostr": { "admins": array, "network_name": "Acme" } })
+    }
+
+    #[test]
+    fn parse_namecoin_network_id_accepts_dot_bit_and_d_prefix() {
+        let bit = parse_namecoin_network_id("AcmeVPN.bit").expect("recognised .bit form");
+        let dformat = parse_namecoin_network_id("d/AcmeVPN").expect("recognised d/ form");
+        assert_eq!(bit.canonical, "d/acmevpn");
+        assert_eq!(dformat.canonical, "d/acmevpn");
+        assert!(bit.subdomain_labels.is_empty());
+
+        let walked = parse_namecoin_network_id("d/acmevpn/eu/west").expect("walks");
+        assert_eq!(walked.canonical, "d/acmevpn");
+        assert_eq!(walked.subdomain_labels, vec!["eu", "west"]);
+    }
+
+    #[test]
+    fn parse_namecoin_network_id_rejects_legacy_opaque_ids() {
+        assert!(parse_namecoin_network_id("nostr-vpn").is_none());
+        assert!(parse_namecoin_network_id("abc123def4567890").is_none());
+        assert!(parse_namecoin_network_id("").is_none());
+        assert!(parse_namecoin_network_id("d/").is_none());
+        assert!(parse_namecoin_network_id("d/-bad").is_none());
+        assert!(parse_namecoin_network_id("not.a.bit.ish").is_none());
+    }
+
+    #[test]
+    fn verify_passes_when_invite_admins_are_subset() {
+        let alice = fake_admin(0x11);
+        let bob = fake_admin(0x22);
+        let chain = ChainNetworkRecord {
+            admins: vec![alice.clone(), bob.clone()],
+            network_name_hint: None,
+        };
+        verify_admins_against_chain(&[alice], &chain).expect("subset accepted");
+    }
+
+    #[test]
+    fn verify_rejects_admin_not_in_chain() {
+        let alice = fake_admin(0x11);
+        let mallory = fake_admin(0x99);
+        let chain = ChainNetworkRecord {
+            admins: vec![alice.clone()],
+            network_name_hint: None,
+        };
+        let err = verify_admins_against_chain(&[alice, mallory], &chain).unwrap_err();
+        assert!(format!("{err}").contains("not in the chain admin set"));
+    }
+
+    #[test]
+    fn verify_rejects_empty_invite_admins() {
+        let chain = ChainNetworkRecord {
+            admins: vec![fake_admin(0x11)],
+            network_name_hint: None,
+        };
+        let err = verify_admins_against_chain(&[], &chain).unwrap_err();
+        assert!(format!("{err}").contains("invite admin list is empty"));
+    }
+
+    #[test]
+    fn verify_rejects_empty_chain_admins() {
+        let chain = ChainNetworkRecord {
+            admins: vec![],
+            network_name_hint: None,
+        };
+        let err = verify_admins_against_chain(&[fake_admin(0x11)], &chain).unwrap_err();
+        assert!(format!("{err}").contains("no admins"));
+    }
+
+    #[tokio::test]
+    async fn resolve_with_transport_returns_admins_for_valid_record() {
+        let alice = fake_admin(0x11);
+        let bob = fake_admin(0x22);
+        let id = parse_namecoin_network_id("acmevpn.bit").unwrap();
+        let transport =
+            StubTransport::new(vec![("d/acmevpn", Ok(Some(fake_record(&[&alice, &bob]))))]);
+        let record = resolve_with_transport(&transport, &id).await.unwrap();
+        assert_eq!(record.admins, vec![alice, bob]);
+        assert_eq!(record.network_name_hint.as_deref(), Some("Acme"));
+    }
+
+    #[tokio::test]
+    async fn resolve_with_transport_walks_subdomain_chain() {
+        let alice = fake_admin(0x11);
+        let parent = serde_json::json!({
+            "map": {
+                "eu": {
+                    "map": {
+                        "west": { "nostr": { "admins": [alice.clone()] } }
+                    }
+                }
+            },
+            "nostr": { "admins": [] }
+        });
+        let id = parse_namecoin_network_id("d/acmevpn/eu/west").unwrap();
+        let transport = StubTransport::new(vec![("d/acmevpn", Ok(Some(parent)))]);
+        let record = resolve_with_transport(&transport, &id).await.unwrap();
+        assert_eq!(record.admins, vec![alice]);
+    }
+
+    #[tokio::test]
+    async fn resolve_with_transport_fails_for_missing_record() {
+        let id = parse_namecoin_network_id("acmevpn.bit").unwrap();
+        let transport = StubTransport::new(vec![("d/acmevpn", Ok(None))]);
+        let err = resolve_with_transport(&transport, &id).await.unwrap_err();
+        assert!(format!("{err}").contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn resolve_with_transport_fails_for_malformed_record() {
+        let id = parse_namecoin_network_id("acmevpn.bit").unwrap();
+        let transport = StubTransport::new(vec![(
+            "d/acmevpn",
+            Ok(Some(
+                serde_json::json!({ "nostr": { "admins": "not-an-array" } }),
+            )),
+        )]);
+        let err = resolve_with_transport(&transport, &id).await.unwrap_err();
+        assert!(format!("{err}").contains("not an array"));
+    }
+
+    #[tokio::test]
+    async fn resolve_with_transport_fails_when_admins_missing() {
+        let id = parse_namecoin_network_id("acmevpn.bit").unwrap();
+        let transport = StubTransport::new(vec![(
+            "d/acmevpn",
+            Ok(Some(serde_json::json!({ "nostr": {} }))),
+        )]);
+        let err = resolve_with_transport(&transport, &id).await.unwrap_err();
+        assert!(format!("{err}").contains("admins"));
+    }
+}

--- a/crates/nostr-vpn-core/tests/config_tests.rs
+++ b/crates/nostr-vpn-core/tests/config_tests.rs
@@ -40,5 +40,7 @@ fn unique_temp_config_path(name: &str) -> std::path::PathBuf {
 mod defaults;
 #[path = "config_tests/magic_dns.rs"]
 mod magic_dns;
+#[path = "config_tests/namecoin.rs"]
+mod namecoin;
 #[path = "config_tests/network.rs"]
 mod network;

--- a/crates/nostr-vpn-core/tests/config_tests/namecoin.rs
+++ b/crates/nostr-vpn-core/tests/config_tests/namecoin.rs
@@ -1,0 +1,152 @@
+use nostr_sdk::prelude::Keys;
+use nostr_vpn_core::config::AppConfig;
+use nostr_vpn_core::namecoin_name_verify::{ChainNetworkRecord, parse_namecoin_network_id};
+use std::collections::HashMap;
+
+fn seed_namecoin_network(network_id: &str, admins: &[String]) -> (AppConfig, Keys) {
+    let own = Keys::generate();
+    let mut config = AppConfig::generated();
+    config.nostr.secret_key = own.secret_key().to_secret_hex();
+    config.nostr.public_key = own.public_key().to_hex();
+    config.networks[0].network_id = network_id.to_string();
+    config.networks[0].admins = admins.to_vec();
+    config.networks[0].participants = admins.to_vec();
+    config.ensure_defaults();
+    (config, own)
+}
+
+#[test]
+fn legacy_network_ids_still_apply_rosters_without_chain_record() {
+    let admin = Keys::generate();
+    let admin_hex = admin.public_key().to_hex();
+    let (mut config, _own) = seed_namecoin_network("mesh-home", std::slice::from_ref(&admin_hex));
+    let own_hex = config.nostr.public_key.clone();
+
+    let changed = config
+        .apply_admin_signed_shared_roster_with_chain(
+            "mesh-home",
+            "Home",
+            vec![admin_hex.clone(), own_hex.clone()],
+            vec![admin_hex.clone()],
+            HashMap::new(),
+            1_726_000_000,
+            &admin_hex,
+            None,
+        )
+        .expect("non-namecoin apply");
+    assert!(changed);
+    assert_eq!(config.networks[0].admins, vec![admin_hex]);
+    assert!(config.networks[0].chain_quarantine_reason.is_empty());
+}
+
+#[test]
+fn namecoin_anchored_roster_apply_quarantines_when_admin_diverges() {
+    let admin = Keys::generate();
+    let admin_hex = admin.public_key().to_hex();
+    let attacker = Keys::generate().public_key().to_hex();
+    let (mut config, _own) = seed_namecoin_network("d/acmevpn", std::slice::from_ref(&admin_hex));
+
+    let chain = ChainNetworkRecord {
+        admins: vec![admin_hex.clone()],
+        network_name_hint: Some("Acme".to_string()),
+    };
+
+    // Proposed roster injects a new admin that is NOT in the chain anchor.
+    let proposed_admins = vec![admin_hex.clone(), attacker.clone()];
+    let changed = config
+        .apply_admin_signed_shared_roster_with_chain(
+            "d/acmevpn",
+            "Acme",
+            vec![admin_hex.clone()],
+            proposed_admins,
+            HashMap::new(),
+            1_726_000_000,
+            &admin_hex,
+            Some(&chain),
+        )
+        .expect("apply returns Ok and quarantines silently");
+    assert!(!changed, "diverging roster must not be applied");
+    assert!(
+        config.networks[0]
+            .chain_quarantine_reason
+            .contains("admin set diverged"),
+        "quarantine reason set: {}",
+        config.networks[0].chain_quarantine_reason
+    );
+}
+
+#[test]
+fn namecoin_anchored_roster_apply_succeeds_for_subset() {
+    let admin = Keys::generate();
+    let admin_hex = admin.public_key().to_hex();
+    let extra = Keys::generate().public_key().to_hex();
+    let (mut config, _own) = seed_namecoin_network("acmevpn.bit", std::slice::from_ref(&admin_hex));
+
+    let chain = ChainNetworkRecord {
+        admins: vec![admin_hex.clone(), extra.clone()],
+        network_name_hint: None,
+    };
+
+    let changed = config
+        .apply_admin_signed_shared_roster_with_chain(
+            "acmevpn.bit",
+            "Acme",
+            vec![admin_hex.clone()],
+            vec![admin_hex.clone(), extra.clone()],
+            HashMap::new(),
+            1_726_000_000,
+            &admin_hex,
+            Some(&chain),
+        )
+        .expect("subset apply");
+    assert!(changed);
+    assert!(config.networks[0].chain_quarantine_reason.is_empty());
+    let mut expected = vec![admin_hex, extra];
+    expected.sort();
+    assert_eq!(config.networks[0].admins, expected);
+}
+
+#[test]
+fn namecoin_anchored_roster_apply_refuses_without_chain_record() {
+    let admin = Keys::generate();
+    let admin_hex = admin.public_key().to_hex();
+    let (mut config, _own) = seed_namecoin_network("d/acmevpn", std::slice::from_ref(&admin_hex));
+
+    let result = config.apply_admin_signed_shared_roster_with_chain(
+        "d/acmevpn",
+        "Acme",
+        vec![admin_hex.clone()],
+        vec![admin_hex.clone()],
+        HashMap::new(),
+        1_726_000_000,
+        &admin_hex,
+        None,
+    );
+    let err = result.expect_err("must refuse anchored apply when chain is missing");
+    assert!(
+        format!("{err}").contains("chain-anchored"),
+        "error mentions chain anchor: {err}"
+    );
+}
+
+#[test]
+fn quarantine_helpers_are_idempotent() {
+    let admin = Keys::generate().public_key().to_hex();
+    let (mut config, _own) = seed_namecoin_network("d/acmevpn", &[admin]);
+
+    assert!(config.quarantine_network("d/acmevpn", "first reason"));
+    assert_eq!(config.networks[0].chain_quarantine_reason, "first reason");
+    assert!(config.quarantine_network("d/acmevpn", "second reason"));
+    assert_eq!(config.networks[0].chain_quarantine_reason, "second reason");
+    assert!(config.clear_network_chain_quarantine("d/acmevpn"));
+    assert!(config.networks[0].chain_quarantine_reason.is_empty());
+    assert!(!config.clear_network_chain_quarantine("d/acmevpn"));
+    assert!(!config.quarantine_network("does-not-exist", "x"));
+}
+
+#[test]
+fn parse_namecoin_network_id_smoke_through_public_api() {
+    assert!(parse_namecoin_network_id("d/acmevpn").is_some());
+    assert!(parse_namecoin_network_id("ACME.bit").is_some());
+    assert!(parse_namecoin_network_id("not-an-anchor").is_none());
+}

--- a/crates/nostr-vpn-core/tests/config_tests/network.rs
+++ b/crates/nostr-vpn-core/tests/config_tests/network.rs
@@ -506,6 +506,7 @@ fn active_network_helpers_ignore_inactive_networks() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         },
         NetworkConfig {
             id: "network-2".to_string(),
@@ -520,6 +521,7 @@ fn active_network_helpers_ignore_inactive_networks() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            chain_quarantine_reason: String::new(),
         },
     ];
     config.ensure_defaults();


### PR DESCRIPTION
# Allow `network_id` to be a Namecoin name with chain-verified admins

## Problem

`network_id` today is an opaque string. Two networks can collide globally,
and there is no out-of-band anchor that says "this is THE real `acmevpn`
and these are its legitimate admins." The admin-signed roster gets
cryptographically verified on the wire — but only after a joiner already
trusts the admin npub from the invite. If someone publishes a fake invite
claiming to be `acmevpn` with a fresh `inviter_npub` and a fresh `admins`
list, joiners have no way to tell.

## Solution

Let `network_id` optionally be a Namecoin name (`d/<name>` or `<name>.bit`).
The chain record's `nostr.admins` array defines the legitimate admin set:

* On `nvpn import-invite`, when the invite's `network_id` parses as a
  Namecoin name, the resolver fetches the chain record and verifies that
  every npub in the invite's `admins` is also in `nostr.admins` on chain.
  Import fails closed on mismatch, missing record, or empty chain admin
  list. A `--insecure-skip-name-verify` flag exists for testing only.
* When a new admin-signed roster is applied to a `.bit`-anchored network
  (daemon roster handler and mobile roster frame handler), the proposed
  admin set is re-checked against the chain anchor. On mismatch the network
  is quarantined (`chain_quarantine_reason` set) and the roster is NOT
  applied. If the chain is unreachable, the network is also quarantined
  rather than silently accepting whatever signed message arrived.
* `nvpn verify-network-name` provides a manual verification command that
  prints the chain admins, local admins, and verdict.
* `nvpn status` surfaces `network_anchor: d/acmevpn ✓ verified-on-import`
  for anchored networks (and `✗ quarantined (...)` after a mismatch).

Admin key rotation and revocation work for free via Namecoin
`name_update` transactions.

## Compatibility

* Non-Namecoin `network_id` values keep working unchanged. The
  `normalize_runtime_network_id` helper still strips the legacy
  `nostr-vpn:` prefix.
* `apply_admin_signed_shared_roster` is unchanged. A new
  `apply_admin_signed_shared_roster_with_chain` wrapper does the
  chain-aware check when the id is recognised as a Namecoin name and
  otherwise delegates straight through.
* New `chain_quarantine_reason` field on `NetworkConfig` is
  `skip_serializing_if = "String::is_empty"`, so existing configs round-trip
  cleanly.

## Failure-closed semantics

| Condition                                  | Behaviour                                  |
| ------------------------------------------ | ------------------------------------------ |
| `.bit` id, chain record missing            | Refuse import / quarantine on roster apply |
| `.bit` id, `nostr.admins` missing or empty | Refuse import / quarantine on roster apply |
| `.bit` id, invite admin not in chain set   | Refuse import (clear error)                |
| `.bit` id, roster admin not in chain set   | Quarantine network, do NOT apply           |
| `.bit` id, chain unreachable at apply time | Quarantine network, do NOT apply           |
| Non-`.bit` id                              | Unchanged behaviour                        |
| Empty invite `admins` list                 | Refuse (sanity check)                      |

## Resolver

Minimal inline implementation at
`crates/nostr-vpn-core/src/namecoin_name_verify.rs`:

* `parse_namecoin_network_id` recognises `<name>.bit` and `d/<name>` (and
  `d/<name>/sub/labels` for ifa-0001 walks). Canonicalises to lowercase
  `d/<name>`.
* `NamecoinTransport` trait allows fully mocked unit tests. Default
  implementation is `ElectrumXTlsTransport` against
  `electrum-nmc.le-space.de:50002` and `nmc.bitcoins.sk:50002` over TLS
  with a 5s timeout, using `tokio-rustls` + `webpki-roots` (the rustls
  stack was already transitive via `nostr-sdk`).
* `verify_admins_against_chain` is a pure synchronous function the config
  layer can call without touching async.

This module carries a `TODO: consolidate with the nostr-vpn-namecoin
crate introduced in the feat/namecoin-resolver PR once that lands` so
the resolver work doesn't fork.

## Tests

* Unit tests in `namecoin_name_verify.rs` cover both `.bit` and `d/`
  forms, ifa-0001 subdomain walks, valid match, partial mismatch,
  empty/missing chain admins, malformed JSON, missing record.
* Integration-style tests in
  `crates/nostr-vpn-core/tests/config_tests/namecoin.rs` cover the
  roster-apply path: subset apply succeeds, divergent apply quarantines
  the network without applying, missing chain record on an anchored
  network is refused, quarantine helpers are idempotent, legacy
  (non-`.bit`) network ids keep applying with `chain: None`.
* The unit and integration suites exercise the parse / verify /
  resolve-with-mock-transport surface that backs the
  `--insecure-skip-name-verify` and `verify-network-name` CLI flows; real
  ElectrumX requests are not made from tests.

## Local acceptance gate

```
cargo fmt --all
cargo fmt --check          # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace     # all suites green
```

## Skipped (per PR scope)

* Docker FIPS join-request / routed-FIPS / NAT safe-MTU e2e
* `just mobile-test-kit` (Android/iOS app-core)
* `( cd linux && cargo check )`

These are unaffected — no protocol, packet, mobile-FFI, or Linux-GTK
changes — but listed here so the maintainer knows what *wasn't* exercised.

## Related

Part of a 3-PR Namecoin integration set. This PR is independent of the
others; the sibling `feat/namecoin-resolver` will replace this module's
vendored resolver with a proper `nostr-vpn-namecoin` crate.
