### PR TITLE
Add Namecoin .bit participant aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,6 +2591,7 @@ dependencies = [
  "hostname",
  "netdev",
  "nostr-sdk 0.35.0",
+ "nostr-vpn-namecoin",
  "serde",
  "serde_json",
  "sha2",
@@ -2600,6 +2601,23 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "nostr-vpn-namecoin"
+version = "4.0.37"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2700,6 +2718,7 @@ name = "nvpn"
 version = "4.0.37"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64",
  "boringtun",
  "clap",
@@ -2712,6 +2731,7 @@ dependencies = [
  "netdev",
  "nostr-sdk 0.35.0",
  "nostr-vpn-core",
+ "nostr-vpn-namecoin",
  "nostr-vpn-wintun",
  "rand 0.9.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/nostr-vpn-app-core/uniffi-bindgen",
   "crates/nostr-vpn-core",
   "crates/nostr-vpn-cli",
+  "crates/nostr-vpn-namecoin",
   "crates/nostr-vpn-web",
   "crates/nostr-vpn-wintun",
 ]
@@ -46,6 +47,7 @@ uniffi = "0.29"
 uuid = { version = "1", features = ["v4", "serde"] }
 nostr-sdk = { version = "0.35", default-features = false, features = ["nip44"] }
 nostr-vpn-core = { version = "4.0.37", path = "crates/nostr-vpn-core" }
+nostr-vpn-namecoin = { version = "4.0.37", path = "crates/nostr-vpn-namecoin" }
 nostr-vpn-wintun = { version = "4.0.37", path = "crates/nostr-vpn-wintun" }
 
 [workspace.lints.clippy]

--- a/crates/nostr-vpn-app-core/src/mobile_tunnel.rs
+++ b/crates/nostr-vpn-app-core/src/mobile_tunnel.rs
@@ -2176,6 +2176,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         app.exit_node = peer.to_string();
 
@@ -2222,6 +2223,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         app.fips_peer_endpoints
             .insert(peer.to_string(), vec!["192.168.50.10:51820".to_string()]);
@@ -2265,6 +2267,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         app.fips_peer_endpoints
             .insert(admin.clone(), vec!["192.168.50.10:51820".to_string()]);
@@ -2319,6 +2322,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         app.ensure_defaults();
 
@@ -2430,6 +2434,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         let requester = Keys::generate().public_key().to_hex();
         let app_config = Arc::new(RwLock::new(app));
@@ -2528,6 +2533,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         admin_app.ensure_defaults();
         admin_app
@@ -2752,6 +2758,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         let config = MobileTunnelConfig::from_app(&app).expect("mobile config");
         let mesh = FipsMeshRuntime::with_local_routes(config.peers.clone(), vec![]);
@@ -2804,6 +2811,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         let config = MobileTunnelConfig::from_app(&app).expect("mobile config");
         let mesh = FipsMeshRuntime::with_local_routes(config.peers.clone(), vec![]);
@@ -2880,6 +2888,7 @@ mod tests {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         }];
         app.wireguard_exit = WireGuardExitConfig {
             enabled: true,

--- a/crates/nostr-vpn-cli/Cargo.toml
+++ b/crates/nostr-vpn-cli/Cargo.toml
@@ -29,6 +29,8 @@ tracing.workspace = true
 nostr-sdk.workspace = true
 
 nostr-vpn-core.workspace = true
+nostr-vpn-namecoin.workspace = true
+async-trait.workspace = true
 crab_nat = "0.7"
 igd-next = { version = "0.16", features = ["aio_tokio"] }
 netdev.workspace = true

--- a/crates/nostr-vpn-cli/src/config_bootstrap.rs
+++ b/crates/nostr-vpn-cli/src/config_bootstrap.rs
@@ -145,7 +145,7 @@ fn uninstall_cli_path(destination: &Path) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn init_config(path: &Path, force: bool, participants: Vec<String>) -> Result<()> {
+pub(crate) async fn init_config(path: &Path, force: bool, participants: Vec<String>) -> Result<()> {
     if path.exists() && !force {
         return Err(anyhow!(
             "config already exists at {} (pass --force to overwrite)",
@@ -154,7 +154,8 @@ pub(crate) fn init_config(path: &Path, force: bool, participants: Vec<String>) -
     }
 
     let mut config = AppConfig::generated();
-    apply_participants_override(&mut config, participants)?;
+    let resolver = crate::namecoin_resolver::ResolverHandle::from_config(&config)?;
+    apply_participants_override_async(&mut config, participants, resolver.as_ref()).await?;
     maybe_autoconfigure_node(&mut config);
     config.save(path)?;
 
@@ -307,6 +308,17 @@ pub(crate) fn apply_participants_override(
         return Ok(());
     }
 
+    // Synchronous path: refuse `.bit` aliases up front rather than silently
+    // failing inside `normalize_nostr_pubkey`. Callers that need alias
+    // support must go through `apply_participants_override_async`.
+    for participant in &participants {
+        if nostr_vpn_namecoin::parse_bit_alias(participant).is_some() {
+            return Err(anyhow!(
+                "'{participant}' is a '.bit' alias; call apply_participants_override_async with a resolver"
+            ));
+        }
+    }
+
     let mut normalized = participants
         .iter()
         .map(|participant| normalize_nostr_pubkey(participant))
@@ -317,6 +329,49 @@ pub(crate) fn apply_participants_override(
     let pending_exit_node = normalize_nostr_pubkey(&config.exit_node).ok();
     config.ensure_defaults();
     config.active_network_mut().participants = normalized.clone();
+    if let Some(exit_node) = pending_exit_node
+        && normalized
+            .iter()
+            .any(|participant| participant == &exit_node)
+    {
+        config.exit_node = exit_node;
+    }
+    let _ = config.note_active_network_roster_local_change();
+    config.ensure_defaults();
+
+    Ok(())
+}
+
+/// Async variant of [`apply_participants_override`] that additionally
+/// understands `.bit` aliases via the supplied resolver. Non-alias inputs
+/// behave identically to the sync version.
+pub(crate) async fn apply_participants_override_async(
+    config: &mut AppConfig,
+    participants: Vec<String>,
+    resolver: Option<&crate::namecoin_resolver::ResolverHandle>,
+) -> Result<()> {
+    if participants.is_empty() {
+        return Ok(());
+    }
+
+    let mut normalized: Vec<String> = Vec::with_capacity(participants.len());
+    let mut alias_pairs: Vec<(String, String)> = Vec::new();
+    for participant in &participants {
+        let resolved = crate::namecoin_resolver::resolve_with_handle(participant, resolver).await?;
+        if let Some(alias) = resolved.alias {
+            alias_pairs.push((resolved.hex_pubkey.clone(), alias));
+        }
+        normalized.push(resolved.hex_pubkey);
+    }
+
+    normalized.sort();
+    normalized.dedup();
+    let pending_exit_node = normalize_nostr_pubkey(&config.exit_node).ok();
+    config.ensure_defaults();
+    config.active_network_mut().participants = normalized.clone();
+    for (hex, alias) in alias_pairs {
+        config.active_network_mut().aliases.insert(hex, alias);
+    }
     if let Some(exit_node) = pending_exit_node
         && normalized
             .iter()

--- a/crates/nostr-vpn-cli/src/main.rs
+++ b/crates/nostr-vpn-cli/src/main.rs
@@ -7,6 +7,7 @@ mod fips_private_mesh;
 mod macos_network;
 #[cfg(any(target_os = "macos", test))]
 mod macos_service;
+mod namecoin_resolver;
 mod network_signaling;
 #[cfg(all(
     feature = "embedded-fips",
@@ -784,7 +785,7 @@ async fn run_command(command: Command) -> Result<()> {
             participants,
         } => {
             let path = config.unwrap_or_else(default_config_path);
-            init_config(&path, force, participants)?;
+            init_config(&path, force, participants).await?;
         }
         Command::Version(args) => {
             print_version(args)?;
@@ -825,7 +826,8 @@ async fn run_command(command: Command) -> Result<()> {
         Command::Status(args) => {
             let config_path = args.config.unwrap_or_else(default_config_path);
             let (app, network_id) =
-                load_config_with_overrides(&config_path, args.network_id, args.participants)?;
+                load_config_with_overrides_async(&config_path, args.network_id, args.participants)
+                    .await?;
             let daemon = daemon_status(&config_path)?;
 
             let daemon_peers: Option<Vec<DaemonPeerState>> = if daemon.running {
@@ -1104,7 +1106,13 @@ async fn run_command(command: Command) -> Result<()> {
             if !args.fips_peer_endpoints.is_empty() {
                 app.fips_peer_endpoints = parse_fips_peer_endpoint_args(&args.fips_peer_endpoints)?;
             }
-            apply_participants_override(&mut app, args.participants)?;
+            let resolver = namecoin_resolver::ResolverHandle::from_config(&app)?;
+            config_bootstrap::apply_participants_override_async(
+                &mut app,
+                args.participants,
+                resolver.as_ref(),
+            )
+            .await?;
             app.ensure_defaults();
             maybe_autoconfigure_node(&mut app);
             app.save(&config_path)?;
@@ -1176,7 +1184,8 @@ async fn run_command(command: Command) -> Result<()> {
         Command::Ping(args) => {
             let config_path = args.config.unwrap_or_else(default_config_path);
             let (app, network_id) =
-                load_config_with_overrides(&config_path, args.network_id, args.participants)?;
+                load_config_with_overrides_async(&config_path, args.network_id, args.participants)
+                    .await?;
             let peers = configured_fips_peer_announcements(&app, &network_id);
 
             let target = resolve_ping_target(&args.target, &peers).ok_or_else(|| {
@@ -1191,7 +1200,8 @@ async fn run_command(command: Command) -> Result<()> {
         Command::Ip(args) => {
             let config_path = args.config.unwrap_or_else(default_config_path);
             let (app, network_id) =
-                load_config_with_overrides(&config_path, args.network_id, args.participants)?;
+                load_config_with_overrides_async(&config_path, args.network_id, args.participants)
+                    .await?;
 
             if !args.peer {
                 let tunnel_ip = runtime_local_tunnel_ip(&app, &network_id);
@@ -1221,7 +1231,8 @@ async fn run_command(command: Command) -> Result<()> {
         Command::Whois(args) => {
             let config_path = args.config.unwrap_or_else(default_config_path);
             let (app, network_id) =
-                load_config_with_overrides(&config_path, args.network_id, args.participants)?;
+                load_config_with_overrides_async(&config_path, args.network_id, args.participants)
+                    .await?;
             let peers = configured_fips_peer_announcements(&app, &network_id);
 
             let found = peers
@@ -1238,11 +1249,23 @@ async fn run_command(command: Command) -> Result<()> {
                 return Err(anyhow!("no peer found for '{}'", args.query));
             };
 
+            let alias = app
+                .network_by_id(&network_id)
+                .and_then(|network| network.aliases.get(&peer.public_key).cloned());
             if args.json {
-                println!("{}", serde_json::to_string_pretty(&peer)?);
+                let mut value = serde_json::to_value(&peer)?;
+                if let Some(alias) = alias.clone()
+                    && let serde_json::Value::Object(map) = &mut value
+                {
+                    map.insert("bit_alias".to_string(), serde_json::Value::String(alias));
+                }
+                println!("{}", serde_json::to_string_pretty(&value)?);
             } else {
                 println!("node_id={}", peer.node_id);
                 println!("public_key={}", peer.public_key);
+                if let Some(alias) = alias {
+                    println!("bit_alias={alias}");
+                }
                 println!("tunnel_ip={}", peer.tunnel_ip);
                 println!("endpoint={}", peer.endpoint);
                 println!("timestamp={}", peer.timestamp);
@@ -2053,6 +2076,24 @@ fn load_config_with_overrides(
 ) -> Result<(AppConfig, String)> {
     let mut app = load_or_default_config(path)?;
     apply_participants_override(&mut app, participants)?;
+    if let Some(network_id) = network_id {
+        app.set_active_network_id(&network_id)?;
+    }
+    maybe_autoconfigure_node(&mut app);
+
+    let network_id = app.effective_network_id();
+    Ok((app, network_id))
+}
+
+async fn load_config_with_overrides_async(
+    path: &Path,
+    network_id: Option<String>,
+    participants: Vec<String>,
+) -> Result<(AppConfig, String)> {
+    let mut app = load_or_default_config(path)?;
+    let resolver = namecoin_resolver::ResolverHandle::from_config(&app)?;
+    config_bootstrap::apply_participants_override_async(&mut app, participants, resolver.as_ref())
+        .await?;
     if let Some(network_id) = network_id {
         app.set_active_network_id(&network_id)?;
     }
@@ -3190,11 +3231,12 @@ pub(crate) fn ensure_macos_connect_privileges(config_path: &Path) -> Result<()> 
 
 async fn start_session(args: StartArgs) -> Result<()> {
     let config_path = args.config.clone().unwrap_or_else(default_config_path);
-    let (app, _network_id) = load_config_with_overrides(
+    let (app, _network_id) = load_config_with_overrides_async(
         &config_path,
         args.network_id.clone(),
         args.participants.clone(),
-    )?;
+    )
+    .await?;
 
     let should_connect = if args.connect {
         true
@@ -3646,7 +3688,7 @@ fn format_health_severity(severity: HealthSeverity) -> &'static str {
 async fn run_doctor(args: DoctorArgs) -> Result<()> {
     let config_path = args.config.unwrap_or_else(default_config_path);
     let (app, network_id) =
-        load_config_with_overrides(&config_path, args.network_id, args.participants)?;
+        load_config_with_overrides_async(&config_path, args.network_id, args.participants).await?;
     let daemon = daemon_status(&config_path)?;
     let netcheck = run_netcheck_report(&app, args.timeout_secs).await;
 
@@ -4132,6 +4174,7 @@ mod tests {
     mod cli_smoke;
     mod config_cache;
     mod daemon_control;
+    mod namecoin_aliases;
     mod runtime_misc;
     mod service_cli;
     pub(crate) mod support;

--- a/crates/nostr-vpn-cli/src/namecoin_resolver.rs
+++ b/crates/nostr-vpn-cli/src/namecoin_resolver.rs
@@ -1,0 +1,79 @@
+//! CLI-side helpers for hooking the Namecoin resolver into pubkey parsing.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use nostr_vpn_core::config::{AppConfig, ResolvedParticipant, resolve_participant_string};
+#[cfg(test)]
+use nostr_vpn_namecoin::MockResolver;
+use nostr_vpn_namecoin::{
+    CachingResolver, ElectrumXResolver, NamecoinError, NamecoinResolver, ResolverConfig,
+    electrumx::parse_servers,
+};
+
+/// A boxed, dynamically-dispatched resolver handle so the CLI can plumb
+/// either a real ElectrumX resolver or a `MockResolver` (tests) through
+/// the same code paths.
+#[derive(Clone)]
+pub(crate) struct ResolverHandle {
+    inner: Arc<dyn NamecoinResolver>,
+}
+
+impl ResolverHandle {
+    pub(crate) fn new<R: NamecoinResolver + 'static>(resolver: R) -> Self {
+        Self {
+            inner: Arc::new(resolver),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_mock(mock: MockResolver) -> Self {
+        Self::new(mock)
+    }
+
+    /// Build a resolver from the provided application config. Returns
+    /// `Ok(None)` when the user has disabled Namecoin lookups so callers
+    /// can still detect bare `.bit` inputs and emit a clean error.
+    pub(crate) fn from_config(config: &AppConfig) -> Result<Option<Self>> {
+        if !config.namecoin.enabled {
+            return Ok(None);
+        }
+        let servers = parse_servers(&config.namecoin.electrumx_servers)?;
+        if servers.is_empty() {
+            return Ok(None);
+        }
+        let resolver_config = ResolverConfig {
+            timeout: Duration::from_secs(config.namecoin.resolution_timeout_secs.max(1)),
+            cache_ttl_positive: Duration::from_secs(config.namecoin.cache_ttl_secs.max(1)),
+            cache_ttl_negative: Duration::from_secs(30),
+        };
+        let inner = ElectrumXResolver::new(servers, resolver_config.clone());
+        let cached = CachingResolver::new(
+            inner,
+            resolver_config.cache_ttl_positive,
+            resolver_config.cache_ttl_negative,
+        );
+        Ok(Some(Self::new(cached)))
+    }
+}
+
+#[async_trait]
+impl NamecoinResolver for ResolverHandle {
+    async fn resolve_nostr_pubkey(
+        &self,
+        alias: &nostr_vpn_namecoin::BitAlias,
+    ) -> Result<String, NamecoinError> {
+        self.inner.resolve_nostr_pubkey(alias).await
+    }
+}
+
+/// Convenience wrapper that runs `resolve_participant_string` with the
+/// CLI-side resolver handle (if any).
+pub(crate) async fn resolve_with_handle(
+    value: &str,
+    handle: Option<&ResolverHandle>,
+) -> Result<ResolvedParticipant> {
+    resolve_participant_string(value, handle).await
+}

--- a/crates/nostr-vpn-cli/src/network_signaling.rs
+++ b/crates/nostr-vpn-cli/src/network_signaling.rs
@@ -291,26 +291,46 @@ pub(crate) async fn update_active_network_roster(
         .id
         .clone();
 
+    let resolver = crate::namecoin_resolver::ResolverHandle::from_config(&app)?;
+
     let mut changed = Vec::new();
     for participant in &args.participants {
+        // Resolve `.bit` aliases (or canonicalize bare pubkeys) up-front so
+        // the per-network mutators only ever see canonical hex/npub input.
+        let resolved =
+            crate::namecoin_resolver::resolve_with_handle(participant, resolver.as_ref()).await?;
+        let canonical = resolved.hex_pubkey.clone();
         let normalized = match action {
             RosterEditAction::AddParticipant => {
-                app.add_participant_to_network(&active_network_id, participant)?
+                app.add_participant_to_network(&active_network_id, &canonical)?
             }
             RosterEditAction::RemoveParticipant => {
-                let normalized = normalize_nostr_pubkey(participant)?;
-                app.remove_participant_from_network(&active_network_id, participant)?;
-                normalized
+                app.remove_participant_from_network(&active_network_id, &canonical)?;
+                canonical.clone()
             }
             RosterEditAction::AddAdmin => {
-                app.add_admin_to_network(&active_network_id, participant)?
+                app.add_admin_to_network(&active_network_id, &canonical)?
             }
             RosterEditAction::RemoveAdmin => {
-                let normalized = normalize_nostr_pubkey(participant)?;
-                app.remove_admin_from_network(&active_network_id, participant)?;
-                normalized
+                app.remove_admin_from_network(&active_network_id, &canonical)?;
+                canonical.clone()
             }
         };
+        if let Some(alias) = resolved.alias
+            && matches!(
+                action,
+                RosterEditAction::AddParticipant | RosterEditAction::AddAdmin
+            )
+            && let Some(network) = app.network_by_id_mut(&active_network_id)
+        {
+            network.aliases.insert(normalized.clone(), alias);
+        } else if matches!(
+            action,
+            RosterEditAction::RemoveParticipant | RosterEditAction::RemoveAdmin
+        ) && let Some(network) = app.network_by_id_mut(&active_network_id)
+        {
+            network.aliases.remove(&normalized);
+        }
         changed.push(normalized);
     }
 

--- a/crates/nostr-vpn-cli/src/tests/config_cache.rs
+++ b/crates/nostr-vpn-cli/src/tests/config_cache.rs
@@ -25,6 +25,7 @@ fn participants_override_targets_the_active_network() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         },
         NetworkConfig {
             id: "work".to_string(),
@@ -39,6 +40,7 @@ fn participants_override_targets_the_active_network() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         },
     ];
     config.ensure_defaults();
@@ -331,6 +333,7 @@ fn config_overrides_set_the_active_network_mesh_id() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         },
         NetworkConfig {
             id: "work".to_string(),
@@ -345,6 +348,7 @@ fn config_overrides_set_the_active_network_mesh_id() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         },
     ];
     config.ensure_defaults();

--- a/crates/nostr-vpn-cli/src/tests/namecoin_aliases.rs
+++ b/crates/nostr-vpn-cli/src/tests/namecoin_aliases.rs
@@ -1,0 +1,133 @@
+//! Integration tests proving the CLI roster/init paths accept `.bit`
+//! aliases when handed a [`MockResolver`].
+
+use nostr_sdk::prelude::{Keys, ToBech32};
+use nostr_vpn_core::config::AppConfig;
+use nostr_vpn_namecoin::MockResolver;
+
+use crate::config_bootstrap::apply_participants_override_async;
+use crate::namecoin_resolver::ResolverHandle;
+
+fn fresh_config() -> AppConfig {
+    let mut config = AppConfig::generated();
+    config.ensure_defaults();
+    config
+}
+
+fn random_pubkey_hex() -> (String, String) {
+    let keys = Keys::generate();
+    let hex = keys.public_key().to_hex();
+    let npub = keys.public_key().to_bech32().unwrap();
+    (hex, npub)
+}
+
+#[tokio::test]
+async fn add_participant_via_bit_alias_resolves_to_hex_and_records_alias() {
+    let (hex, _npub) = random_pubkey_hex();
+
+    let mock = MockResolver::new();
+    mock.insert("alice@example.bit", hex.clone());
+    let handle = ResolverHandle::from_mock(mock);
+
+    let mut config = fresh_config();
+    apply_participants_override_async(
+        &mut config,
+        vec!["alice@example.bit".to_string()],
+        Some(&handle),
+    )
+    .await
+    .expect("resolve and apply");
+
+    let network = config.active_network();
+    assert!(
+        network.participants.iter().any(|p| p == &hex),
+        "expected canonical hex in participants: {:?}",
+        network.participants
+    );
+    assert_eq!(
+        network.aliases.get(&hex).map(String::as_str),
+        Some("alice@example.bit"),
+        "expected stored alias for participant"
+    );
+}
+
+#[tokio::test]
+async fn apex_alias_resolves_through_resolver() {
+    let (hex, _npub) = random_pubkey_hex();
+
+    let mock = MockResolver::new();
+    mock.insert("example.bit", hex.clone());
+    let handle = ResolverHandle::from_mock(mock);
+
+    let mut config = fresh_config();
+    apply_participants_override_async(&mut config, vec!["example.bit".to_string()], Some(&handle))
+        .await
+        .expect("resolve and apply");
+
+    assert!(config.active_network().participants.contains(&hex));
+    assert_eq!(
+        config
+            .active_network()
+            .aliases
+            .get(&hex)
+            .map(String::as_str),
+        Some("example.bit"),
+    );
+}
+
+#[tokio::test]
+async fn npub_input_still_works_with_alias_path() {
+    let (hex, npub) = random_pubkey_hex();
+    let mock = MockResolver::new();
+    let handle = ResolverHandle::from_mock(mock);
+
+    let mut config = fresh_config();
+    apply_participants_override_async(&mut config, vec![npub.clone()], Some(&handle))
+        .await
+        .expect("resolve and apply");
+
+    assert!(
+        config.active_network().participants.contains(&hex),
+        "npub should normalize to hex"
+    );
+    assert!(
+        config.active_network().aliases.is_empty(),
+        "npub input must not record an alias"
+    );
+}
+
+#[tokio::test]
+async fn unknown_bit_alias_surfaces_clear_error() {
+    let mock = MockResolver::new();
+    let handle = ResolverHandle::from_mock(mock);
+
+    let mut config = fresh_config();
+    let err = apply_participants_override_async(
+        &mut config,
+        vec!["ghost@nope.bit".to_string()],
+        Some(&handle),
+    )
+    .await
+    .expect_err("unknown alias should fail");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("ghost@nope.bit"),
+        "error should mention the alias, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn alias_without_resolver_errors_cleanly() {
+    let mut config = fresh_config();
+    let err =
+        apply_participants_override_async(&mut config, vec!["alice@example.bit".to_string()], None)
+            .await
+            .expect_err("missing resolver must fail");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("alice@example.bit"),
+        "error should mention the alias, got: {message}"
+    );
+}

--- a/crates/nostr-vpn-core/Cargo.toml
+++ b/crates/nostr-vpn-core/Cargo.toml
@@ -24,6 +24,7 @@ thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
+nostr-vpn-namecoin.workspace = true
 uuid.workspace = true
 hex.workspace = true
 hickory-proto.workspace = true

--- a/crates/nostr-vpn-core/src/config.rs
+++ b/crates/nostr-vpn-core/src/config.rs
@@ -21,6 +21,11 @@ pub use crate::network_routes::{
     exit_node_default_routes, normalize_advertised_route, normalize_advertised_routes,
 };
 
+pub use crate::config_defaults::{
+    ResolvedParticipant, maybe_autoconfigure_node, needs_endpoint_autoconfig,
+    needs_tunnel_ip_autoconfig, normalize_nostr_pubkey, normalize_runtime_network_id,
+    resolve_participant_string,
+};
 use crate::config_defaults::{
     current_unix_timestamp, default_autoconnect, default_close_to_tray_on_close, default_endpoint,
     default_fips_advertise_endpoint, default_lan_discovery_enabled, default_launch_on_startup,
@@ -28,10 +33,6 @@ use crate::config_defaults::{
     default_nat_enabled, default_nat_stun_servers, default_network_enabled, default_network_id,
     default_node_id, default_relays, default_tunnel_ip, generate_nostr_identity, is_true, is_zero,
     needs_generated_network_id, npub_for_pubkey_hex,
-};
-pub use crate::config_defaults::{
-    maybe_autoconfigure_node, needs_endpoint_autoconfig, needs_tunnel_ip_autoconfig,
-    normalize_nostr_pubkey, normalize_runtime_network_id,
 };
 use crate::config_magic_dns::{
     default_magic_dns_suffix, default_network_entry_id, default_network_name, default_node_name,
@@ -142,6 +143,56 @@ pub struct AppConfig {
     pub nostr: NostrConfig,
     #[serde(default)]
     pub node: NodeConfig,
+    #[serde(default)]
+    pub namecoin: NamecoinConfig,
+}
+
+/// Configuration for the Namecoin `.bit` alias resolver.
+///
+/// `enabled = true` keeps things turned on by default; users that want the
+/// daemon to refuse all `.bit` lookups can set `enabled = false`. All other
+/// fields fall back to safe defaults if omitted, so existing configs keep
+/// loading unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamecoinConfig {
+    #[serde(default = "default_namecoin_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_namecoin_electrumx_servers")]
+    pub electrumx_servers: Vec<String>,
+    #[serde(default = "default_namecoin_resolution_timeout_secs")]
+    pub resolution_timeout_secs: u64,
+    #[serde(default = "default_namecoin_cache_ttl_secs")]
+    pub cache_ttl_secs: u64,
+}
+
+impl Default for NamecoinConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_namecoin_enabled(),
+            electrumx_servers: default_namecoin_electrumx_servers(),
+            resolution_timeout_secs: default_namecoin_resolution_timeout_secs(),
+            cache_ttl_secs: default_namecoin_cache_ttl_secs(),
+        }
+    }
+}
+
+pub(crate) fn default_namecoin_enabled() -> bool {
+    true
+}
+
+pub(crate) fn default_namecoin_electrumx_servers() -> Vec<String> {
+    vec![
+        "electrum-nmc.le-space.de:50002".to_string(),
+        "nmc.bitcoins.sk:50002".to_string(),
+    ]
+}
+
+pub(crate) const fn default_namecoin_resolution_timeout_secs() -> u64 {
+    5
+}
+
+pub(crate) const fn default_namecoin_cache_ttl_secs() -> u64 {
+    300
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -598,6 +649,11 @@ pub struct NetworkConfig {
     pub shared_roster_updated_at: u64,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub shared_roster_signed_by: String,
+    /// Optional human-readable aliases (e.g. `.bit` names) for participants.
+    /// Keyed by canonical hex pubkey. Populated when a participant is added
+    /// using a `.bit` alias; surfaced in `status`/`ip`/`whois` output.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub aliases: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -654,6 +710,7 @@ impl Default for AppConfig {
                 inbound_join_requests: Vec::new(),
                 shared_roster_updated_at: 0,
                 shared_roster_signed_by: String::new(),
+                aliases: HashMap::new(),
             }],
             node_name: default_node_name(),
             lan_discovery_enabled: default_lan_discovery_enabled(),
@@ -673,6 +730,7 @@ impl Default for AppConfig {
             nat: NatConfig::default(),
             nostr: NostrConfig::default(),
             node: NodeConfig::default(),
+            namecoin: NamecoinConfig::default(),
         };
         config.ensure_defaults();
         config
@@ -1059,6 +1117,7 @@ impl AppConfig {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: HashMap::new(),
         });
         let _ = self.note_network_roster_local_change(&id);
         id

--- a/crates/nostr-vpn-core/src/config_defaults.rs
+++ b/crates/nostr-vpn-core/src/config_defaults.rs
@@ -30,6 +30,48 @@ pub fn normalize_nostr_pubkey(value: &str) -> Result<String> {
         .map_err(|error| anyhow::anyhow!("invalid participant pubkey '{value}': {error}"))
 }
 
+/// Outcome of resolving a CLI participant string: the canonical hex pubkey
+/// plus the alias (if the user typed a `.bit` name) so callers can preserve
+/// it for later display in `status`/`ip`/`whois` output.
+#[derive(Debug, Clone)]
+pub struct ResolvedParticipant {
+    pub hex_pubkey: String,
+    pub alias: Option<String>,
+}
+
+/// Async sibling of [`normalize_nostr_pubkey`] that additionally accepts
+/// `.bit` aliases. Inputs that are already valid npub/hex are returned
+/// unchanged (modulo canonicalization) without touching the resolver, so
+/// existing call sites that never use aliases pay no network cost.
+pub async fn resolve_participant_string<R>(
+    value: &str,
+    resolver: Option<&R>,
+) -> Result<ResolvedParticipant>
+where
+    R: nostr_vpn_namecoin::NamecoinResolver + ?Sized,
+{
+    if let Some(alias) = nostr_vpn_namecoin::parse_bit_alias(value) {
+        let resolver = resolver.ok_or_else(|| {
+            anyhow::anyhow!("namecoin resolver disabled; cannot resolve '.bit' alias '{value}'")
+        })?;
+        let hex = resolver
+            .resolve_nostr_pubkey(&alias)
+            .await
+            .map_err(|error| anyhow::anyhow!("failed to resolve '{value}': {error}"))?;
+        let normalized = normalize_nostr_pubkey(&hex)?;
+        return Ok(ResolvedParticipant {
+            hex_pubkey: normalized,
+            alias: Some(alias.to_string()),
+        });
+    }
+
+    let normalized = normalize_nostr_pubkey(value)?;
+    Ok(ResolvedParticipant {
+        hex_pubkey: normalized,
+        alias: None,
+    })
+}
+
 pub(crate) fn default_nat_enabled() -> bool {
     true
 }

--- a/crates/nostr-vpn-core/tests/config_tests/network.rs
+++ b/crates/nostr-vpn-core/tests/config_tests/network.rs
@@ -506,6 +506,7 @@ fn active_network_helpers_ignore_inactive_networks() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         },
         NetworkConfig {
             id: "network-2".to_string(),
@@ -520,6 +521,7 @@ fn active_network_helpers_ignore_inactive_networks() {
             inbound_join_requests: Vec::new(),
             shared_roster_updated_at: 0,
             shared_roster_signed_by: String::new(),
+            aliases: std::collections::HashMap::new(),
         },
     ];
     config.ensure_defaults();

--- a/crates/nostr-vpn-namecoin/Cargo.toml
+++ b/crates/nostr-vpn-namecoin/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nostr-vpn-namecoin"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Namecoin .bit alias resolver for Nostr VPN (ifa-0001 / NIP-05-over-Namecoin)"
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true }
+tracing.workspace = true
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pki-types = "1"
+webpki-roots = "0.26"
+
+[dev-dependencies]
+tokio = { workspace = true }
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nostr-vpn-namecoin/src/alias.rs
+++ b/crates/nostr-vpn-namecoin/src/alias.rs
@@ -1,0 +1,257 @@
+//! Parsing for `.bit` alias strings.
+
+use std::fmt;
+
+/// A parsed `.bit` alias.
+///
+/// Two forms are accepted:
+///
+/// - `Apex` — an unqualified `.bit` name like `example.bit`. Resolution
+///   reads `nostr.names["_"]` (or `nostr.names["<root>"]` per ifa-0001
+///   when the apex entry is absent).
+/// - `Localpart` — a name with an explicit localpart, written either as
+///   `alice@example.bit` (NIP-05 style) or `alice.example.bit`
+///   (DNS-style subdomain).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BitAlias {
+    Apex(String),
+    Localpart { local: String, parent: String },
+}
+
+impl BitAlias {
+    /// Returns the underlying `.bit` parent name (without subdomain labels).
+    #[must_use]
+    pub fn parent(&self) -> &str {
+        match self {
+            Self::Apex(name) | Self::Localpart { parent: name, .. } => name,
+        }
+    }
+
+    /// Returns the localpart used when reading `nostr.names`. For an apex
+    /// alias this is `"_"`.
+    #[must_use]
+    pub fn local(&self) -> &str {
+        match self {
+            Self::Apex(_) => "_",
+            Self::Localpart { local, .. } => local,
+        }
+    }
+}
+
+impl fmt::Display for BitAlias {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Apex(name) => formatter.write_str(name),
+            Self::Localpart { local, parent } => write!(formatter, "{local}@{parent}"),
+        }
+    }
+}
+
+/// Parse a candidate participant string into a [`BitAlias`].
+///
+/// Returns `Some` only if the input looks like a `.bit` name. Anything else
+/// (npub, hex, junk) returns `None` so callers can cleanly fall through to
+/// the existing pubkey parser.
+///
+/// ```
+/// use nostr_vpn_namecoin::{BitAlias, parse_bit_alias};
+///
+/// assert_eq!(parse_bit_alias("example.bit"),
+///     Some(BitAlias::Apex("example.bit".into())));
+///
+/// assert_eq!(parse_bit_alias("EXAMPLE.BIT"),
+///     Some(BitAlias::Apex("example.bit".into())));
+///
+/// assert_eq!(parse_bit_alias("alice@example.bit"),
+///     Some(BitAlias::Localpart { local: "alice".into(), parent: "example.bit".into() }));
+///
+/// assert_eq!(parse_bit_alias("alice.example.bit"),
+///     Some(BitAlias::Localpart { local: "alice".into(), parent: "example.bit".into() }));
+///
+/// // Deeper subdomains: only the leftmost label is treated as the local part.
+/// // (v1 supports a single subdomain hop; deeper trees still attempt the same walk.)
+/// assert_eq!(parse_bit_alias("a.b.c.bit"),
+///     Some(BitAlias::Localpart { local: "a".into(), parent: "b.c.bit".into() }));
+///
+/// // Non-.bit inputs return None so callers fall back to normal pubkey parsing.
+/// assert_eq!(parse_bit_alias("npub1exampleexample"), None);
+/// assert_eq!(parse_bit_alias("not-a-name"), None);
+/// assert_eq!(parse_bit_alias(".bit"), None);
+/// ```
+#[must_use]
+pub fn parse_bit_alias(value: &str) -> Option<BitAlias> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Reject control / whitespace inside the name.
+    if trimmed.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let suffix_start = lower.len().checked_sub(".bit".len())?;
+    if &lower[suffix_start..] != ".bit" {
+        return None;
+    }
+
+    // Split optional localpart written as `local@parent`.
+    if let Some((local, parent)) = lower.split_once('@') {
+        if local.is_empty() || parent.is_empty() {
+            return None;
+        }
+        if !valid_label(local) {
+            return None;
+        }
+        // The bit suffix must live on the parent side. `lower` is already
+        // lowercased above, so a plain `ends_with` is sufficient (the
+        // file-extension lint is irrelevant — these are domain names).
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        let parent_ok = parent.ends_with(".bit");
+        if !parent_ok {
+            return None;
+        }
+        let parent_root = parent.strip_suffix(".bit").unwrap_or(parent);
+        if parent_root.is_empty() || !valid_dns_name(parent_root) {
+            return None;
+        }
+        return Some(BitAlias::Localpart {
+            local: local.to_string(),
+            parent: parent.to_string(),
+        });
+    }
+
+    // No `@`. Inspect the dot-separated labels of the bare name.
+    let stripped = &lower[..suffix_start];
+    if stripped.is_empty() {
+        return None;
+    }
+
+    let labels: Vec<&str> = stripped.split('.').collect();
+    for label in &labels {
+        if !valid_label(label) {
+            return None;
+        }
+    }
+
+    if labels.len() == 1 {
+        return Some(BitAlias::Apex(lower));
+    }
+
+    // Treat the leftmost label as the localpart; everything else is the
+    // parent `.bit` name. This matches the ifa-0001 walk: the resolver will
+    // descend `map` entries label-by-label, but for v1 we only support a
+    // single hop and a "deep" name like `a.b.c.bit` is treated as
+    // `local=a, parent=b.c.bit`.
+    let (local, rest) = labels.split_first().expect("non-empty after check");
+    let parent = format!("{}.bit", rest.join("."));
+
+    Some(BitAlias::Localpart {
+        local: (*local).to_string(),
+        parent,
+    })
+}
+
+fn valid_label(label: &str) -> bool {
+    if label.is_empty() || label.len() > 63 {
+        return false;
+    }
+    label
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && !label.starts_with('-')
+        && !label.ends_with('-')
+}
+
+fn valid_dns_name(name: &str) -> bool {
+    name.split('.').all(valid_label)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apex_parses() {
+        assert_eq!(
+            parse_bit_alias("example.bit"),
+            Some(BitAlias::Apex("example.bit".into()))
+        );
+    }
+
+    #[test]
+    fn apex_case_insensitive() {
+        assert_eq!(
+            parse_bit_alias("Example.BIT"),
+            Some(BitAlias::Apex("example.bit".into()))
+        );
+    }
+
+    #[test]
+    fn nip05_style_localpart() {
+        assert_eq!(
+            parse_bit_alias("alice@example.bit"),
+            Some(BitAlias::Localpart {
+                local: "alice".into(),
+                parent: "example.bit".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn dns_style_localpart() {
+        assert_eq!(
+            parse_bit_alias("alice.example.bit"),
+            Some(BitAlias::Localpart {
+                local: "alice".into(),
+                parent: "example.bit".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn deep_name_treats_leftmost_label_as_local() {
+        assert_eq!(
+            parse_bit_alias("a.b.c.bit"),
+            Some(BitAlias::Localpart {
+                local: "a".into(),
+                parent: "b.c.bit".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_non_bit() {
+        assert!(parse_bit_alias("example.com").is_none());
+        assert!(parse_bit_alias("npub1examplenope").is_none());
+        assert!(parse_bit_alias("not-a-name").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_or_pathological() {
+        assert!(parse_bit_alias("").is_none());
+        assert!(parse_bit_alias(".bit").is_none());
+        assert!(parse_bit_alias("@example.bit").is_none());
+        assert!(parse_bit_alias("alice@.bit").is_none());
+        assert!(parse_bit_alias("alice@example.com").is_none());
+        assert!(parse_bit_alias("alice with space@example.bit").is_none());
+        assert!(parse_bit_alias("alice@example .bit").is_none());
+    }
+
+    #[test]
+    fn display_round_trips_logical_form() {
+        let alias = parse_bit_alias("alice.example.bit").unwrap();
+        assert_eq!(alias.to_string(), "alice@example.bit");
+
+        let apex = parse_bit_alias("example.bit").unwrap();
+        assert_eq!(apex.to_string(), "example.bit");
+    }
+
+    #[test]
+    fn apex_local_is_underscore() {
+        let apex = parse_bit_alias("example.bit").unwrap();
+        assert_eq!(apex.local(), "_");
+        assert_eq!(apex.parent(), "example.bit");
+    }
+}

--- a/crates/nostr-vpn-namecoin/src/cache.rs
+++ b/crates/nostr-vpn-namecoin/src/cache.rs
@@ -1,0 +1,124 @@
+//! TTL caching wrapper around any [`NamecoinResolver`].
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+use crate::alias::BitAlias;
+use crate::resolver::{NamecoinError, NamecoinResolver};
+
+#[derive(Clone)]
+enum CachedOutcome {
+    Hit(String),
+    Miss(String),
+}
+
+struct Entry {
+    outcome: CachedOutcome,
+    expires_at: Instant,
+}
+
+/// Wraps an inner resolver with per-process TTL caching.
+pub struct CachingResolver<R: NamecoinResolver> {
+    inner: R,
+    positive_ttl: Duration,
+    negative_ttl: Duration,
+    entries: Mutex<HashMap<String, Entry>>,
+}
+
+impl<R: NamecoinResolver> CachingResolver<R> {
+    pub fn new(inner: R, positive_ttl: Duration, negative_ttl: Duration) -> Self {
+        Self {
+            inner,
+            positive_ttl,
+            negative_ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn lookup(&self, key: &str) -> Option<CachedOutcome> {
+        let mut guard = self.entries.lock().expect("cache lock poisoned");
+        let now = Instant::now();
+        if let Some(entry) = guard.get(key)
+            && entry.expires_at > now
+        {
+            return Some(entry.outcome.clone());
+        }
+        // GC the stale entry if present.
+        guard.remove(key);
+        None
+    }
+
+    fn store(&self, key: String, outcome: CachedOutcome) {
+        let ttl = match &outcome {
+            CachedOutcome::Hit(_) => self.positive_ttl,
+            CachedOutcome::Miss(_) => self.negative_ttl,
+        };
+        let mut guard = self.entries.lock().expect("cache lock poisoned");
+        guard.insert(
+            key,
+            Entry {
+                outcome,
+                expires_at: Instant::now() + ttl,
+            },
+        );
+    }
+}
+
+#[async_trait]
+impl<R: NamecoinResolver> NamecoinResolver for CachingResolver<R> {
+    async fn resolve_nostr_pubkey(&self, alias: &BitAlias) -> Result<String, NamecoinError> {
+        let key = alias.to_string();
+        if let Some(outcome) = self.lookup(&key) {
+            return match outcome {
+                CachedOutcome::Hit(hex) => Ok(hex),
+                CachedOutcome::Miss(msg) => Err(NamecoinError::Generic(msg)),
+            };
+        }
+
+        match self.inner.resolve_nostr_pubkey(alias).await {
+            Ok(hex) => {
+                self.store(key, CachedOutcome::Hit(hex.clone()));
+                Ok(hex)
+            }
+            Err(error) => {
+                // Cache only "stable" misses; treat transport errors as
+                // transient and skip caching.
+                let cacheable = matches!(
+                    error,
+                    NamecoinError::NotFound { .. }
+                        | NamecoinError::NoNostrEntry { .. }
+                        | NamecoinError::MalformedValue { .. }
+                        | NamecoinError::Expired { .. }
+                        | NamecoinError::InvalidPubkey { .. }
+                );
+                if cacheable {
+                    self.store(key, CachedOutcome::Miss(error.to_string()));
+                }
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alias::parse_bit_alias;
+    use crate::mock::MockResolver;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn positive_results_are_cached() {
+        let mock = MockResolver::new();
+        mock.insert("alice@example.bit", "a".repeat(64));
+        let cached = CachingResolver::new(mock, Duration::from_secs(60), Duration::from_secs(10));
+        let alias = parse_bit_alias("alice@example.bit").unwrap();
+
+        let first = cached.resolve_nostr_pubkey(&alias).await.unwrap();
+        let second = cached.resolve_nostr_pubkey(&alias).await.unwrap();
+        assert_eq!(first, second);
+    }
+}

--- a/crates/nostr-vpn-namecoin/src/electrumx.rs
+++ b/crates/nostr-vpn-namecoin/src/electrumx.rs
@@ -1,0 +1,559 @@
+//! `ElectrumX`-backed `NamecoinResolver` implementation.
+//!
+//! Implements the subset of the `ElectrumX` protocol required to fetch a
+//! Namecoin name value: a single `blockchain.name.get` JSON-RPC call over
+//! either TLS or plain TCP. The reply is parsed as ifa-0001 Domain Name
+//! Object JSON and walked to `nostr.names[<local>]`.
+
+use std::io;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use anyhow::{Context, anyhow};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+use tokio_rustls::TlsConnector;
+use tokio_rustls::rustls;
+use tokio_rustls::rustls::pki_types::ServerName;
+
+use crate::alias::BitAlias;
+use crate::resolver::{NamecoinError, NamecoinResolver, ResolverConfig, validate_hex_pubkey};
+
+/// One configured `ElectrumX` endpoint.
+#[derive(Debug, Clone)]
+pub struct ElectrumXServer {
+    pub host: String,
+    pub port: u16,
+    pub use_tls: bool,
+}
+
+impl ElectrumXServer {
+    /// Parse a `host:port` or `ssl://host:port`/`tcp://host:port` spec.
+    pub fn parse(raw: &str) -> anyhow::Result<Self> {
+        let (scheme_tls, rest) = if let Some(rest) = raw.strip_prefix("ssl://") {
+            (true, rest)
+        } else if let Some(rest) = raw.strip_prefix("tcp://") {
+            (false, rest)
+        } else {
+            (true, raw)
+        };
+        let (host, port_str) = rest
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow!("electrumx server must include port: {raw}"))?;
+        let port: u16 = port_str
+            .parse()
+            .with_context(|| format!("invalid electrumx port: {port_str}"))?;
+        if host.is_empty() {
+            return Err(anyhow!("electrumx host must not be empty"));
+        }
+        Ok(Self {
+            host: host.to_string(),
+            port,
+            use_tls: scheme_tls,
+        })
+    }
+}
+
+/// `ElectrumX` resolver.
+pub struct ElectrumXResolver {
+    servers: Vec<ElectrumXServer>,
+    config: ResolverConfig,
+}
+
+impl ElectrumXResolver {
+    /// Build a resolver with the provided servers and config.
+    #[must_use]
+    pub fn new(servers: Vec<ElectrumXServer>, config: ResolverConfig) -> Self {
+        Self { servers, config }
+    }
+
+    /// Default server set used when the user hasn't overridden it.
+    #[must_use]
+    pub fn default_servers() -> Vec<ElectrumXServer> {
+        vec![
+            ElectrumXServer {
+                host: "electrum-nmc.le-space.de".to_string(),
+                port: 50002,
+                use_tls: true,
+            },
+            ElectrumXServer {
+                host: "nmc.bitcoins.sk".to_string(),
+                port: 50002,
+                use_tls: true,
+            },
+        ]
+    }
+
+    async fn fetch_name(&self, name: &str) -> Result<String, NamecoinError> {
+        if self.servers.is_empty() {
+            return Err(NamecoinError::Generic(
+                "no electrumx servers configured".to_string(),
+            ));
+        }
+        let mut last_error: Option<anyhow::Error> = None;
+        for server in &self.servers {
+            match timeout(self.config.timeout, fetch_name_from_server(server, name)).await {
+                Ok(Ok(value)) => return Ok(value),
+                Ok(Err(error)) => {
+                    if let Some(transport) = error.downcast_ref::<NameLookupError>()
+                        && matches!(transport, NameLookupError::NotFound)
+                    {
+                        return Err(NamecoinError::NotFound {
+                            name: name.to_string(),
+                        });
+                    }
+                    last_error = Some(error);
+                }
+                Err(_) => {
+                    last_error = Some(anyhow!(
+                        "electrumx request to {}:{} timed out after {:?}",
+                        server.host,
+                        server.port,
+                        self.config.timeout
+                    ));
+                }
+            }
+        }
+        let error =
+            last_error.unwrap_or_else(|| anyhow!("electrumx request failed without an error"));
+        Err(NamecoinError::Transport {
+            server: self
+                .servers
+                .iter()
+                .map(|s| format!("{}:{}", s.host, s.port))
+                .collect::<Vec<_>>()
+                .join(","),
+            source: error,
+        })
+    }
+}
+
+#[async_trait]
+impl NamecoinResolver for ElectrumXResolver {
+    async fn resolve_nostr_pubkey(&self, alias: &BitAlias) -> Result<String, NamecoinError> {
+        // Walk the alias parent (e.g. `example.bit` → `d/example`).
+        // For `a.b.c.bit` we look up `d/c` (root) and walk via `map` into b → a.
+        let parent_no_suffix = alias
+            .parent()
+            .strip_suffix(".bit")
+            .unwrap_or(alias.parent())
+            .to_string();
+
+        // Split the parent into labels (most-specific first). The TLD
+        // equivalent is the last label: `b.c.bit` → `[b, c]` → root is `c`.
+        let parent_labels: Vec<&str> = parent_no_suffix.split('.').collect();
+        let root_label = parent_labels
+            .last()
+            .copied()
+            .ok_or_else(|| NamecoinError::Generic("empty .bit parent".to_string()))?;
+
+        // Subdomain labels to walk through `map`, ordered top-down. For
+        // `alice.example.bit` (local=alice, parent=example.bit) we look up
+        // root `d/example` and read `nostr.names[alice]` directly. For
+        // `a.b.c.bit` (local=a, parent=b.c.bit) we descend `map["b"]` and
+        // then read `nostr.names[a]`.
+        let mut map_walk: Vec<String> = parent_labels
+            .iter()
+            .rev()
+            .skip(1)
+            .map(|s| (*s).to_string())
+            .collect();
+        map_walk.reverse();
+
+        let local = alias.local().to_string();
+
+        let mut import_hops = 0u8;
+        let mut current_name = format!("d/{root_label}");
+
+        loop {
+            let raw_value = self.fetch_name(&current_name).await?;
+            let walked = walk_namecoin_value(&current_name, &raw_value, &map_walk, &local)?;
+            match walked {
+                WalkOutcome::Pubkey(hex) => {
+                    return validate_hex_pubkey(&current_name, &hex);
+                }
+                WalkOutcome::Import(target) => {
+                    import_hops += 1;
+                    if import_hops > 1 {
+                        return Err(NamecoinError::ImportLimit { name: current_name });
+                    }
+                    current_name = target;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum NameLookupError {
+    #[error("name not found")]
+    NotFound,
+}
+
+async fn fetch_name_from_server(server: &ElectrumXServer, name: &str) -> anyhow::Result<String> {
+    let request = serde_json::json!({
+        "id": 1,
+        "method": "blockchain.name.get",
+        "params": [name],
+    });
+    let mut payload = serde_json::to_vec(&request)?;
+    payload.push(b'\n');
+
+    let response = if server.use_tls {
+        send_tls(server, &payload).await?
+    } else {
+        send_plain(server, &payload).await?
+    };
+
+    parse_response(&response)
+}
+
+async fn send_plain(server: &ElectrumXServer, payload: &[u8]) -> anyhow::Result<String> {
+    let mut stream = TcpStream::connect((server.host.as_str(), server.port)).await?;
+    stream.write_all(payload).await?;
+    let mut reader = BufReader::new(stream);
+    let mut buf = String::new();
+    reader.read_line(&mut buf).await?;
+    Ok(buf)
+}
+
+async fn send_tls(server: &ElectrumXServer, payload: &[u8]) -> anyhow::Result<String> {
+    let connector = tls_connector();
+    let tcp = TcpStream::connect((server.host.as_str(), server.port)).await?;
+    let dns_name = ServerName::try_from(server.host.clone())
+        .map_err(|err| anyhow!("invalid TLS server name {}: {err}", server.host))?;
+    let mut tls = connector.connect(dns_name, tcp).await?;
+    tls.write_all(payload).await?;
+    let mut reader = BufReader::new(tls);
+    let mut buf = String::new();
+    reader.read_line(&mut buf).await?;
+    Ok(buf)
+}
+
+fn tls_connector() -> TlsConnector {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    let config = CONFIG
+        .get_or_init(|| {
+            let mut roots = rustls::RootCertStore::empty();
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            let cfg = rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+            Arc::new(cfg)
+        })
+        .clone();
+    TlsConnector::from(config)
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcEnvelope {
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<Value>,
+}
+
+fn parse_response(line: &str) -> anyhow::Result<String> {
+    if line.trim().is_empty() {
+        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "empty response").into());
+    }
+    let envelope: JsonRpcEnvelope =
+        serde_json::from_str(line).with_context(|| format!("invalid JSON-RPC response: {line}"))?;
+    if let Some(error) = envelope.error {
+        // ElectrumX returns either a string or a structured error.
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .map_or_else(|| error.to_string(), str::to_string);
+        if message.to_ascii_lowercase().contains("not found")
+            || message.to_ascii_lowercase().contains("unknown name")
+        {
+            return Err(NameLookupError::NotFound.into());
+        }
+        return Err(anyhow!("electrumx error: {message}"));
+    }
+    let result = envelope
+        .result
+        .ok_or_else(|| anyhow!("electrumx response missing result"))?;
+    // ElectrumX `blockchain.name.get` returns an object with a `value`
+    // string. Some servers wrap it differently — accept both shapes.
+    if let Some(obj) = result.as_object() {
+        if let Some(value) = obj.get("value").and_then(Value::as_str) {
+            return Ok(value.to_string());
+        }
+        if let Some(value) = obj.get("value") {
+            return Ok(value.to_string());
+        }
+    }
+    if let Some(value) = result.as_str() {
+        return Ok(value.to_string());
+    }
+    Err(anyhow!("electrumx response missing name value"))
+}
+
+#[derive(Debug)]
+enum WalkOutcome {
+    Pubkey(String),
+    Import(String),
+}
+
+fn walk_namecoin_value(
+    name: &str,
+    raw_value: &str,
+    map_walk: &[String],
+    local: &str,
+) -> Result<WalkOutcome, NamecoinError> {
+    let root: Value =
+        serde_json::from_str(raw_value).map_err(|err| NamecoinError::MalformedValue {
+            name: name.to_string(),
+            reason: format!("invalid JSON: {err}"),
+        })?;
+    let mut current = &root;
+
+    // Walk through `map[label]` entries.
+    for label in map_walk {
+        let next = current
+            .get("map")
+            .and_then(|m| m.get(label.as_str()))
+            .ok_or_else(|| NamecoinError::NoNostrEntry {
+                name: name.to_string(),
+                local: local.to_string(),
+            })?;
+        current = next;
+    }
+
+    // Expired records: ifa-0001 uses `expires_in <= 0` or `expired: true`.
+    // Check this before reading `nostr.names` so callers see the precise
+    // "this record is dead" error rather than treating it as a hit.
+    if let Some(expired) = current.get("expired").and_then(Value::as_bool)
+        && expired
+    {
+        return Err(NamecoinError::Expired {
+            name: name.to_string(),
+        });
+    }
+    if let Some(expires_in) = current.get("expires_in").and_then(Value::as_i64)
+        && expires_in <= 0
+    {
+        return Err(NamecoinError::Expired {
+            name: name.to_string(),
+        });
+    }
+
+    // Look for nostr.names[local].
+    if let Some(nostr) = current.get("nostr")
+        && let Some(names) = nostr.get("names")
+    {
+        if let Some(value) = names.get(local).and_then(Value::as_str) {
+            return Ok(WalkOutcome::Pubkey(value.to_string()));
+        }
+        // Apex fallback: when looking up "_" but the publisher used the
+        // root label as the key (ifa-0001 quirk), try that too.
+        if local == "_" {
+            // Walk up to find a sensible label: use the first segment of
+            // the lookup name (e.g. `d/example` → `example`).
+            if let Some(root_label) = name.strip_prefix("d/")
+                && let Some(value) = names.get(root_label).and_then(Value::as_str)
+            {
+                return Ok(WalkOutcome::Pubkey(value.to_string()));
+            }
+        }
+    }
+
+    // Look for `import` redirect.
+    if let Some(import) = current.get("import").and_then(Value::as_str) {
+        return Ok(WalkOutcome::Import(import.to_string()));
+    }
+
+    Err(NamecoinError::NoNostrEntry {
+        name: name.to_string(),
+        local: local.to_string(),
+    })
+}
+
+/// Convenience: build an `ElectrumXResolver` from a list of `host:port`
+/// strings using the default configuration.
+pub fn parse_servers(raw: &[String]) -> anyhow::Result<Vec<ElectrumXServer>> {
+    raw.iter()
+        .map(|spec| ElectrumXServer::parse(spec))
+        .collect()
+}
+
+/// Wrap a duration value (seconds) with sane defaults if the input is zero.
+#[must_use]
+pub fn duration_or_default(seconds: u64, default_secs: u64) -> Duration {
+    if seconds == 0 {
+        Duration::from_secs(default_secs)
+    } else {
+        Duration::from_secs(seconds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_value(value: &serde_json::Value) -> String {
+        value.to_string()
+    }
+
+    #[test]
+    fn parse_servers_accepts_bare_hostport() {
+        let server = ElectrumXServer::parse("electrum.example.org:50002").unwrap();
+        assert_eq!(server.host, "electrum.example.org");
+        assert_eq!(server.port, 50002);
+        assert!(server.use_tls);
+    }
+
+    #[test]
+    fn parse_servers_honours_scheme() {
+        let tls = ElectrumXServer::parse("ssl://electrum.example.org:50002").unwrap();
+        assert!(tls.use_tls);
+        let plain = ElectrumXServer::parse("tcp://electrum.example.org:50001").unwrap();
+        assert!(!plain.use_tls);
+    }
+
+    #[test]
+    fn walks_apex_nostr_underscore_entry() {
+        let value = raw_value(&serde_json::json!({
+            "nostr": {
+                "names": {
+                    "_": "a".repeat(64)
+                }
+            }
+        }));
+        let outcome = walk_namecoin_value("d/example", &value, &[], "_").unwrap();
+        let WalkOutcome::Pubkey(hex) = outcome else {
+            panic!("expected pubkey");
+        };
+        assert_eq!(hex, "a".repeat(64));
+    }
+
+    #[test]
+    fn walks_localpart_entry() {
+        let value = raw_value(&serde_json::json!({
+            "nostr": {
+                "names": {
+                    "alice": "b".repeat(64)
+                }
+            }
+        }));
+        let outcome = walk_namecoin_value("d/example", &value, &[], "alice").unwrap();
+        let WalkOutcome::Pubkey(hex) = outcome else {
+            panic!("expected pubkey");
+        };
+        assert_eq!(hex, "b".repeat(64));
+    }
+
+    #[test]
+    fn walks_map_subtree() {
+        let value = raw_value(&serde_json::json!({
+            "map": {
+                "team": {
+                    "nostr": {
+                        "names": {
+                            "alice": "c".repeat(64)
+                        }
+                    }
+                }
+            }
+        }));
+        let outcome =
+            walk_namecoin_value("d/example", &value, &["team".to_string()], "alice").unwrap();
+        let WalkOutcome::Pubkey(hex) = outcome else {
+            panic!("expected pubkey");
+        };
+        assert_eq!(hex, "c".repeat(64));
+    }
+
+    #[test]
+    fn surfaces_import_redirects() {
+        let value = raw_value(&serde_json::json!({
+            "import": "d/other"
+        }));
+        let outcome = walk_namecoin_value("d/example", &value, &[], "_").unwrap();
+        let WalkOutcome::Import(target) = outcome else {
+            panic!("expected import");
+        };
+        assert_eq!(target, "d/other");
+    }
+
+    #[test]
+    fn missing_local_returns_clear_error() {
+        let value = raw_value(&serde_json::json!({
+            "nostr": {
+                "names": {
+                    "bob": "d".repeat(64)
+                }
+            }
+        }));
+        let err = walk_namecoin_value("d/example", &value, &[], "alice").unwrap_err();
+        match err {
+            NamecoinError::NoNostrEntry { name, local } => {
+                assert_eq!(name, "d/example");
+                assert_eq!(local, "alice");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_json_is_reported() {
+        let err = walk_namecoin_value("d/example", "not json", &[], "_").unwrap_err();
+        assert!(matches!(err, NamecoinError::MalformedValue { .. }));
+    }
+
+    #[test]
+    fn expired_records_are_rejected() {
+        let value = raw_value(&serde_json::json!({
+            "expired": true,
+            "nostr": { "names": { "_": "e".repeat(64) } }
+        }));
+        let err = walk_namecoin_value("d/example", &value, &[], "_").unwrap_err();
+        assert!(matches!(err, NamecoinError::Expired { .. }));
+    }
+
+    #[test]
+    fn validates_pubkey_format() {
+        let value = raw_value(&serde_json::json!({
+            "nostr": { "names": { "_": "not-hex" } }
+        }));
+        // The walk returns the string; the resolver then validates it.
+        let outcome = walk_namecoin_value("d/example", &value, &[], "_").unwrap();
+        let WalkOutcome::Pubkey(hex) = outcome else {
+            panic!("expected pubkey");
+        };
+        let err = validate_hex_pubkey("d/example", &hex).unwrap_err();
+        assert!(matches!(err, NamecoinError::InvalidPubkey { .. }));
+    }
+
+    #[test]
+    fn jsonrpc_response_value_field_is_extracted() {
+        let response = serde_json::json!({
+            "id": 1,
+            "result": {
+                "value": "{\"nostr\":{\"names\":{\"_\":\"f\"}}}"
+            },
+            "error": null,
+        });
+        let line = format!("{response}\n");
+        let value = parse_response(&line).unwrap();
+        assert!(value.starts_with('{'));
+    }
+
+    #[test]
+    fn jsonrpc_not_found_maps_to_lookup_error() {
+        let response = serde_json::json!({
+            "id": 1,
+            "result": null,
+            "error": { "code": -1, "message": "name not found" },
+        });
+        let line = format!("{response}\n");
+        let err = parse_response(&line).unwrap_err();
+        assert!(err.downcast_ref::<NameLookupError>().is_some());
+    }
+}

--- a/crates/nostr-vpn-namecoin/src/lib.rs
+++ b/crates/nostr-vpn-namecoin/src/lib.rs
@@ -1,0 +1,34 @@
+//! Namecoin `.bit` alias resolution for Nostr VPN.
+//!
+//! Resolves human-readable `.bit` names (e.g. `alice@example.bit` or
+//! `example.bit`) to 32-byte hex Nostr pubkeys by walking the Namecoin
+//! name tree via `ElectrumX`. The semantics follow the ifa-0001 Domain Name
+//! Object and the NIP-05-over-Namecoin / "N1" track that has been deployed
+//! by other Nostr clients (Amethyst, nostr-tools, Nostur, dart-nostr, strfry).
+//!
+//! Lookup procedure:
+//!
+//! 1. Strip the `.bit` suffix and split off any subdomain labels.
+//! 2. Look up `d/<root>` on an `ElectrumX` server via `blockchain.name.get`.
+//! 3. Parse the value as JSON. Walk the `map` subtree using ifa-0001
+//!    semantics for any leading subdomain labels.
+//! 4. Read `nostr.names[<local>]` (or `nostr.names["_"]` for an apex
+//!    request without an explicit localpart) and return that hex pubkey.
+//! 5. Honour a single `import` redirect when encountered (v1 limit).
+//!
+//! The crate ships an in-process TTL cache so back-to-back lookups for the
+//! same name don't hammer `ElectrumX`.
+
+#![forbid(unsafe_code)]
+
+pub mod alias;
+pub mod cache;
+pub mod electrumx;
+pub mod mock;
+pub mod resolver;
+
+pub use alias::{BitAlias, parse_bit_alias};
+pub use cache::CachingResolver;
+pub use electrumx::{ElectrumXResolver, ElectrumXServer};
+pub use mock::MockResolver;
+pub use resolver::{NamecoinError, NamecoinResolver, ResolverConfig};

--- a/crates/nostr-vpn-namecoin/src/mock.rs
+++ b/crates/nostr-vpn-namecoin/src/mock.rs
@@ -1,0 +1,69 @@
+//! In-memory resolver used by tests and offline tooling.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::alias::BitAlias;
+use crate::resolver::{NamecoinError, NamecoinResolver};
+
+/// Toy resolver that returns canned results.
+///
+/// Inserts use the canonical alias display form (e.g. `alice@example.bit`
+/// or `example.bit`).
+#[derive(Default)]
+pub struct MockResolver {
+    entries: Mutex<HashMap<String, String>>,
+}
+
+impl MockResolver {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pre-register an alias → hex pubkey mapping.
+    pub fn insert(&self, alias: impl Into<String>, hex_pubkey: impl Into<String>) {
+        let mut guard = self.entries.lock().expect("mock entries lock poisoned");
+        guard.insert(alias.into(), hex_pubkey.into());
+    }
+}
+
+#[async_trait]
+impl NamecoinResolver for MockResolver {
+    async fn resolve_nostr_pubkey(&self, alias: &BitAlias) -> Result<String, NamecoinError> {
+        let key = alias.to_string();
+        let guard = self.entries.lock().expect("mock entries lock poisoned");
+        guard
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| NamecoinError::NoNostrEntry {
+                name: alias.parent().to_string(),
+                local: alias.local().to_string(),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alias::parse_bit_alias;
+
+    #[tokio::test]
+    async fn returns_inserted_pubkey() {
+        let resolver = MockResolver::new();
+        resolver.insert("alice@example.bit", "a".repeat(64));
+        let alias = parse_bit_alias("alice@example.bit").unwrap();
+        let hex = resolver.resolve_nostr_pubkey(&alias).await.unwrap();
+        assert_eq!(hex, "a".repeat(64));
+    }
+
+    #[tokio::test]
+    async fn missing_alias_returns_not_found() {
+        let resolver = MockResolver::new();
+        let alias = parse_bit_alias("alice@example.bit").unwrap();
+        let err = resolver.resolve_nostr_pubkey(&alias).await.unwrap_err();
+        assert!(matches!(err, NamecoinError::NoNostrEntry { .. }));
+    }
+}

--- a/crates/nostr-vpn-namecoin/src/resolver.rs
+++ b/crates/nostr-vpn-namecoin/src/resolver.rs
@@ -1,0 +1,77 @@
+//! Resolver trait and supporting types.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::alias::BitAlias;
+
+/// Public error type returned by resolvers.
+#[derive(Debug, Error)]
+pub enum NamecoinError {
+    #[error("namecoin: {0}")]
+    Generic(String),
+    #[error("namecoin: connection to {server} failed: {source}")]
+    Transport {
+        server: String,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("namecoin: name '{name}' not found")]
+    NotFound { name: String },
+    #[error("namecoin: name '{name}' has no `nostr.names` entry for '{local}'")]
+    NoNostrEntry { name: String, local: String },
+    #[error("namecoin: malformed value for '{name}': {reason}")]
+    MalformedValue { name: String, reason: String },
+    #[error("namecoin: expired record for '{name}'")]
+    Expired { name: String },
+    #[error("namecoin: import loop or unsupported depth resolving '{name}'")]
+    ImportLimit { name: String },
+    #[error("namecoin: invalid pubkey '{value}' for '{name}': {reason}")]
+    InvalidPubkey {
+        name: String,
+        value: String,
+        reason: String,
+    },
+}
+
+/// Configuration shared by all built-in resolvers.
+#[derive(Debug, Clone)]
+pub struct ResolverConfig {
+    pub timeout: Duration,
+    pub cache_ttl_positive: Duration,
+    pub cache_ttl_negative: Duration,
+}
+
+impl Default for ResolverConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(5),
+            cache_ttl_positive: Duration::from_secs(300),
+            cache_ttl_negative: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Resolver abstraction. Implementations are responsible for whatever
+/// transport they need (`ElectrumX`, local namecoind RPC, mock, ...).
+#[async_trait]
+pub trait NamecoinResolver: Send + Sync {
+    /// Resolve `alias` to a 32-byte hex Nostr pubkey (lowercase, 64 chars).
+    async fn resolve_nostr_pubkey(&self, alias: &BitAlias) -> Result<String, NamecoinError>;
+}
+
+/// Validate that `value` is a 32-byte hex string. Returns the lowercased
+/// canonical form on success.
+pub(crate) fn validate_hex_pubkey(name: &str, value: &str) -> Result<String, NamecoinError> {
+    let trimmed = value.trim();
+    if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(NamecoinError::InvalidPubkey {
+            name: name.to_string(),
+            value: trimmed.to_string(),
+            reason: "expected 64-char lowercase hex Nostr pubkey".to_string(),
+        });
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}


### PR DESCRIPTION
# Add Namecoin `.bit` participant aliases

## What

Anywhere the CLI currently accepts an `npub`/hex pubkey for a participant or
admin (e.g. `nvpn add-participant`, `nvpn add-admin`, `--participant` overrides
on `ping`/`doctor`/`ip`/`whois`/`set`/`init`/`start`), you can now pass a
human-readable `.bit` name instead:

```sh
nvpn add-participant alice@example.bit       # → resolves to nostr.names["alice"]
nvpn add-participant example.bit             # → resolves to nostr.names["_"]
```

Existing `npub1...` / hex inputs keep working unchanged.

## Why

Namecoin `.bit` names give Nostr identities a human-readable handle that
isn't anchored in a central directory — the mapping lives on a public chain.
The same `nostr.names[<local>]` convention is already implemented by
Amethyst, nostr-tools, Nostur, dart-nostr, and strfry; this PR is the Rust
port for `nvpn` so mesh rosters get the same affordance.

## How

- New `crates/nostr-vpn-namecoin/` crate:
  - `BitAlias` + `parse_bit_alias` for `.bit` input parsing (accepts
    `example.bit`, `alice@example.bit`, and the DNS-style `alice.example.bit`;
    case-insensitive).
  - `NamecoinResolver` async trait.
  - `ElectrumXResolver` implementation: single `blockchain.name.get` JSON-RPC
    call over TLS (rustls + webpki roots) or plain TCP. Walks the ifa-0001
    Domain Name Object, descending `map` subtrees label-by-label, reading
    `nostr.names[<local>]`, honouring a single `import` redirect.
  - `CachingResolver` wraps any resolver with positive (5 min default) /
    negative (30 s default) TTL caching.
  - `MockResolver` used by tests.
- `nostr-vpn-core` adds:
  - `app.namecoin` config section (enabled/electrumx_servers/timeout/cache TTL,
    all `serde(default)` so existing configs load unchanged).
  - Per-network `aliases: HashMap<hex_pubkey, bit_name>` so the user-typed
    alias survives roundtripping through save/load and shows up in
    `nvpn whois` output as `bit_alias=alice@example.bit`.
  - `resolve_participant_string(value, resolver)` async sibling of
    `normalize_nostr_pubkey`, which is the single chokepoint every CLI
    participant string goes through. The sync `normalize_nostr_pubkey`
    keeps its existing fast-path for non-alias inputs; only `.bit` names
    take the async route.
- `nostr-vpn-cli`:
  - `apply_participants_override_async` and `load_config_with_overrides_async`
    take an optional resolver handle and plumb resolved aliases all the way
    through into the per-network `aliases` map.
  - `update_active_network_roster` (the dispatch for `add-participant` /
    `remove-participant` / `add-admin` / `remove-admin`) resolves up-front
    and passes canonical hex into the existing per-network mutators.
  - `nvpn whois` surfaces the alias in both plain-text and JSON output.

## Compatibility

- Configs without the `[app.namecoin]` table keep loading; every field has a
  `serde(default)` and a sensible default value.
- All existing `npub1...` / hex inputs go through the same code path with no
  network calls; only `.bit` inputs touch the resolver.
- Opt-out: set `app.namecoin.enabled = false`. With it off, `.bit` inputs
  return a clear error pointing at the disabled flag rather than silently
  falling through.

## Tests

- `crates/nostr-vpn-namecoin` ships 24 unit tests + 1 doctest covering:
  alias parsing (apex, NIP-05-style, DNS-style, deep names, case folding,
  pathological inputs), ifa-0001 walking (apex, subdomain via `map`,
  `import` redirect, malformed JSON, expired records, invalid hex),
  `ElectrumXServer` parsing, JSON-RPC envelope handling (`value` field +
  `not found` mapping), and the TTL cache.
- `crates/nostr-vpn-cli/src/tests/namecoin_aliases.rs` exercises the full
  CLI plumbing with `MockResolver`: `add-participant alice@example.bit`
  lands the right hex in the roster *and* stores the alias; npub-only
  input still works; missing alias surfaces a clear error; missing
  resolver surfaces a clear error.

Local acceptance gate (all green):

```
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

Docker FIPS e2e and the mobile test kits were **not** run locally — those
are CI/release gates, not PR gates. CI will run the regular lint+test gate.

## Limits / follow-ups

- v1 supports a **single** `import` hop. Deeper `import` chains return
  `ImportLimit`. Worth lifting once we see real-world chains that need it.
- No TLSA pinning on the `ElectrumX` SSL connection — it relies on the
  Web PKI cert chain plus DNS resolution of the bootstrap server hostname.
  That's the same trust model as the other Nostr clients in this ecosystem,
  but pinning would be a worthwhile follow-up issue.
- The default `ElectrumX` server set is two community-operated nodes; the
  list is configurable via `app.namecoin.electrumx_servers`.

## Related

Part of a 3-PR set. The follow-up PRs stack on the resolver crate
introduced here (kept separate so this one stays small and reviewable on
its own).
