### PR TITLE
Fix macOS WG upstream bypass routes

### DIFF
--- a/crates/nostr-vpn-cli/src/fips_private_mesh.rs
+++ b/crates/nostr-vpn-cli/src/fips_private_mesh.rs
@@ -1076,7 +1076,7 @@ impl FipsPrivateMeshRuntime {
             .collect())
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub(crate) async fn peer_transport_ipv4_hosts(&self) -> Result<Vec<Ipv4Addr>> {
         let mut hosts = self
             .endpoint
@@ -1759,6 +1759,17 @@ fn fips_udp_external_addr(transport: &FipsEndpointTransportConfig) -> Option<Str
     Some(endpoint.to_string())
 }
 
+fn fips_ipv4_bypass_hosts<I>(control_plane_hosts: &[Ipv4Addr], peer_hosts: I) -> Vec<Ipv4Addr>
+where
+    I: IntoIterator<Item = Ipv4Addr>,
+{
+    let mut bypass_hosts = control_plane_hosts.to_vec();
+    bypass_hosts.extend(peer_hosts);
+    bypass_hosts.sort_unstable();
+    bypass_hosts.dedup();
+    bypass_hosts
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct FipsPrivateTunnelConfig {
     pub(crate) identity_nsec: String,
@@ -1783,7 +1794,7 @@ pub(crate) struct FipsPrivateTunnelConfig {
     nostr_discovery_policy: NostrDiscoveryPolicy,
     open_discovery_max_pending: usize,
     mesh_mtu: MeshMtu,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub(crate) control_plane_bypass_hosts: Vec<Ipv4Addr>,
 }
 
@@ -1939,7 +1950,7 @@ impl FipsPrivateTunnelConfig {
             nostr_discovery_policy: fips_nostr_discovery_policy_from_app(app),
             open_discovery_max_pending,
             mesh_mtu: private_mesh_mtu_from_app(Some(app)),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             control_plane_bypass_hosts: crate::control_plane_bypass_ipv4_hosts(app),
         })
     }
@@ -2007,7 +2018,7 @@ fn tag_authenticated_transport_addr(
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn endpoint_transport_ipv4_host(addr: &str) -> Option<Ipv4Addr> {
     if let Ok(socket_addr) = addr.parse::<SocketAddr>() {
         return match socket_addr.ip() {
@@ -2258,6 +2269,8 @@ impl FipsPrivateTunnelRuntime {
 
         #[cfg(target_os = "macos")]
         {
+            let config = self.config.clone();
+            self.reconcile_macos_wg_upstream(&config).await;
             Ok(())
         }
     }
@@ -2364,8 +2377,7 @@ impl FipsPrivateTunnelRuntime {
                 config.mesh_mtu.tunnel,
             )
             .with_context(|| format!("failed to configure FIPS tunnel interface {}", self.iface))?;
-            self.reconcile_macos_wg_upstream(&config.wireguard_exit)
-                .await;
+            self.reconcile_macos_wg_upstream(config).await;
             self.reconcile_macos_exit_node_forwarding(
                 &config.local_address,
                 &config.local_advertised_routes,
@@ -2415,24 +2427,30 @@ impl FipsPrivateTunnelRuntime {
     /// Called on every `apply_interface_config` (which fires on
     /// startup, on every config change, and on the periodic
     /// peer-dependent route refresh). The function is idempotent: a
-    /// no-op if the existing tunnel already matches the config, a
-    /// teardown-then-bring-up if the config changed, just a teardown
-    /// if WG is now disabled.
+    /// no-op if the existing tunnel already matches the config and
+    /// current bypass hosts, a teardown-then-bring-up if either changed,
+    /// just a teardown if WG is now disabled.
     ///
     /// **Safe-by-construction**: if the WG handshake doesn't complete
     /// within the watchdog window (10s), nothing modifies the routing
     /// table. The host's default route only ever swaps to the WG tun
     /// after we've seen a real handshake from the upstream.
     #[cfg(target_os = "macos")]
-    async fn reconcile_macos_wg_upstream(&mut self, wg_config: &WireGuardExitConfig) {
+    async fn reconcile_macos_wg_upstream(&mut self, config: &FipsPrivateTunnelConfig) {
+        let wg_config = &config.wireguard_exit;
         let want_up = wg_config.enabled && wg_config.configured();
+        let bypass_hosts = if want_up {
+            self.macos_wg_upstream_bypass_hosts(config).await
+        } else {
+            Vec::new()
+        };
 
         // Already up with matching config → nothing to do.
         if want_up
             && self
                 .wg_upstream
                 .as_ref()
-                .is_some_and(|existing| existing.matches(wg_config))
+                .is_some_and(|existing| existing.matches(wg_config, &bypass_hosts))
         {
             return;
         }
@@ -2451,6 +2469,7 @@ impl FipsPrivateTunnelRuntime {
         match crate::wg_upstream_runtime::apply_daemon_wg_upstream(
             wg_config,
             crate::wg_upstream_runtime::DAEMON_WG_UPSTREAM_HANDSHAKE_TIMEOUT,
+            &bypass_hosts,
         )
         .await
         {
@@ -2470,6 +2489,23 @@ impl FipsPrivateTunnelRuntime {
                 eprintln!("fips: WG upstream not started: {error}");
             }
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn macos_wg_upstream_bypass_hosts(
+        &self,
+        config: &FipsPrivateTunnelConfig,
+    ) -> Vec<Ipv4Addr> {
+        let mut peer_hosts = Vec::new();
+        match self.mesh.peer_transport_ipv4_hosts().await {
+            Ok(hosts) => peer_hosts = hosts,
+            Err(error) => {
+                eprintln!(
+                    "fips: WG upstream continuing without peer transport bypass hosts: {error}"
+                );
+            }
+        }
+        fips_ipv4_bypass_hosts(&config.control_plane_bypass_hosts, peer_hosts)
     }
 
     #[cfg(target_os = "macos")]
@@ -2604,10 +2640,8 @@ impl FipsPrivateTunnelRuntime {
         }
 
         let endpoint_bypass_specs = if original_route_targets_require_bypass || strict_exit {
-            let mut bypass_hosts = config.control_plane_bypass_hosts.clone();
-            bypass_hosts.extend(peer_endpoint_hosts);
-            bypass_hosts.sort_unstable();
-            bypass_hosts.dedup();
+            let bypass_hosts =
+                fips_ipv4_bypass_hosts(&config.control_plane_bypass_hosts, peer_endpoint_hosts);
             crate::linux_bypass_route_specs_for_hosts(
                 bypass_hosts,
                 &self.iface,
@@ -4050,10 +4084,10 @@ mod tests {
         FipsPrivateMeshRuntime, FipsPrivateTunnelConfig, Ipv4Subnet,
         cap_recent_non_roster_transit_endpoints, control_frame_destination_npub,
         control_frame_source_pubkey, drain_event_batch, filter_static_tunnel_endpoints,
-        fips_endpoint_config, fips_endpoint_peers_from_mesh, fips_lan_discovery_scope,
-        fips_peer_address_from_hint, linux_cap_eff_has_net_admin, linux_tun_setup_error,
-        other_endpoint_peer_statuses, parse_fips_nostr_discovery_policy, strip_cidr,
-        tag_authenticated_transport_addr, unix_timestamp,
+        fips_endpoint_config, fips_endpoint_peers_from_mesh, fips_ipv4_bypass_hosts,
+        fips_lan_discovery_scope, fips_peer_address_from_hint, linux_cap_eff_has_net_admin,
+        linux_tun_setup_error, other_endpoint_peer_statuses, parse_fips_nostr_discovery_policy,
+        strip_cidr, tag_authenticated_transport_addr, unix_timestamp,
     };
     use fips_endpoint::{
         Config, ConnectPolicy, FipsEndpointPeer, NostrDiscoveryPolicy,
@@ -4071,6 +4105,31 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::net::{IpAddr, Ipv4Addr, UdpSocket};
     use std::time::Duration;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn fips_ipv4_bypass_hosts_uses_current_config_and_peer_hosts() {
+        let hosts = fips_ipv4_bypass_hosts(
+            &[
+                "198.51.100.20".parse().expect("ip"),
+                "203.0.113.7".parse().expect("ip"),
+            ],
+            vec![
+                "192.0.2.5".parse().expect("ip"),
+                "198.51.100.20".parse().expect("ip"),
+                "192.0.2.5".parse().expect("ip"),
+            ],
+        );
+
+        assert_eq!(
+            hosts,
+            vec![
+                "192.0.2.5".parse::<Ipv4Addr>().expect("ip"),
+                "198.51.100.20".parse().expect("ip"),
+                "203.0.113.7".parse().expect("ip"),
+            ]
+        );
+    }
 
     #[test]
     fn parses_fips_nostr_discovery_policy_override() {

--- a/crates/nostr-vpn-cli/src/main.rs
+++ b/crates/nostr-vpn-cli/src/main.rs
@@ -1764,7 +1764,7 @@ async fn run_wg_upstream_replace_default(
     // guard restores the original default + deletes the bypass on
     // Drop, so a panic / Ctrl-C from this point on still recovers.
     let mtu = if cfg.mtu > 0 { cfg.mtu } else { 1420 };
-    let mut full_route = apply_full_default_route(&actual_iface, &cfg.address, upstream, mtu)
+    let mut full_route = apply_full_default_route(&actual_iface, &cfg.address, upstream, mtu, &[])
         .with_context(|| {
             format!(
                 "swap default route via {actual_iface} (probably needs root). \

--- a/crates/nostr-vpn-cli/src/platform_routing.rs
+++ b/crates/nostr-vpn-cli/src/platform_routing.rs
@@ -1,12 +1,12 @@
 #[cfg(target_os = "linux")]
 use std::fs;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::net::IpAddr;
 #[cfg(any(target_os = "linux", target_os = "macos", test))]
 use std::net::Ipv4Addr;
 #[cfg(any(target_os = "linux", target_os = "macos", test))]
 use std::net::Ipv6Addr;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::net::ToSocketAddrs;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::process::Command as ProcessCommand;
@@ -15,11 +15,11 @@ use std::process::Command as ProcessCommand;
 use anyhow::Context;
 #[cfg(any(target_os = "linux", target_os = "macos", test))]
 use anyhow::{Result, anyhow};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use netdev::get_interfaces;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use netdev::interface::interface::Interface as NetworkInterface;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use nostr_vpn_core::config::AppConfig;
 
 #[cfg(any(target_os = "macos", test))]
@@ -208,7 +208,7 @@ pub(crate) fn flush_linux_route_cache() -> Result<()> {
     )
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn relay_bypass_ipv4_hosts(app: &AppConfig) -> Vec<Ipv4Addr> {
     let mut hosts = app
         .nostr
@@ -221,7 +221,7 @@ fn relay_bypass_ipv4_hosts(app: &AppConfig) -> Vec<Ipv4Addr> {
     hosts
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn relay_ipv4_hosts(relay: &str) -> Vec<Ipv4Addr> {
     let Some((host, port)) = relay_host_port(relay) else {
         return Vec::new();
@@ -248,7 +248,7 @@ fn relay_ipv4_hosts(relay: &str) -> Vec<Ipv4Addr> {
         .unwrap_or_default()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
 fn relay_host_port(relay: &str) -> Option<(String, u16)> {
     let relay = relay.trim();
     if relay.is_empty() {
@@ -267,7 +267,7 @@ fn relay_host_port(relay: &str) -> Option<(String, u16)> {
     split_host_port(authority, default_port)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
 pub(crate) fn stun_host_port(server: &str) -> Option<(String, u16)> {
     let server = server.trim();
     if server.is_empty() {
@@ -282,7 +282,7 @@ pub(crate) fn stun_host_port(server: &str) -> Option<(String, u16)> {
     split_host_port(authority, 3478)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn stun_ipv4_hosts(app: &AppConfig) -> Vec<Ipv4Addr> {
     let mut hosts = app
         .nat
@@ -316,7 +316,7 @@ fn stun_ipv4_hosts(app: &AppConfig) -> Vec<Ipv4Addr> {
     hosts
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn management_ipv4_hosts_from_interfaces(interfaces: &[NetworkInterface]) -> Vec<Ipv4Addr> {
     let mut hosts = interfaces
         .iter()
@@ -341,7 +341,7 @@ fn management_ipv4_hosts_from_interfaces(interfaces: &[NetworkInterface]) -> Vec
     hosts
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub(crate) fn control_plane_bypass_ipv4_hosts_from_interfaces(
     app: &AppConfig,
     interfaces: &[NetworkInterface],
@@ -354,12 +354,12 @@ pub(crate) fn control_plane_bypass_ipv4_hosts_from_interfaces(
     hosts
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub(crate) fn control_plane_bypass_ipv4_hosts(app: &AppConfig) -> Vec<Ipv4Addr> {
     control_plane_bypass_ipv4_hosts_from_interfaces(app, &get_interfaces())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
 pub(crate) fn split_host_port(authority: &str, default_port: u16) -> Option<(String, u16)> {
     let authority = authority.trim();
     if authority.is_empty() {
@@ -1163,6 +1163,30 @@ mod tests {
         assert!(!linux_route_target_is_ipv4("::/0"));
         assert!(linux_route_target_is_ipv6("::/0"));
         assert!(!linux_route_target_is_ipv6("10.44.0.0/16"));
+    }
+
+    #[test]
+    fn platform_routing_parses_relay_and_stun_host_ports() {
+        assert_eq!(
+            relay_host_port("wss://relay.example.com"),
+            Some(("relay.example.com".to_string(), 443))
+        );
+        assert_eq!(
+            relay_host_port("ws://relay.example.com:8080/path"),
+            Some(("relay.example.com".to_string(), 8080))
+        );
+        assert_eq!(
+            relay_host_port("relay.example.com"),
+            Some(("relay.example.com".to_string(), 80))
+        );
+        assert_eq!(
+            stun_host_port("stun:stun.example.com"),
+            Some(("stun.example.com".to_string(), 3478))
+        );
+        assert_eq!(
+            stun_host_port("[2001:db8::1]:5349"),
+            Some(("2001:db8::1".to_string(), 5349))
+        );
     }
 
     #[test]

--- a/crates/nostr-vpn-cli/src/wg_upstream_runtime.rs
+++ b/crates/nostr-vpn-cli/src/wg_upstream_runtime.rs
@@ -7,7 +7,7 @@
 //! `DaemonWgUpstream` lifecycle holder that the daemon's reconcile
 //! loop owns.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 #[cfg(target_os = "windows")]
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
@@ -315,8 +315,9 @@ pub struct ScopedHostRoute {
 
 /// Full default-route replacement: bring up the userspace WG tun and
 /// route **all** outbound traffic through it (Mullvad/Proton-style),
-/// while installing a bypass /32 route for the WG endpoint itself so
-/// the encrypted UDP keeps escaping via the original default route.
+/// while installing bypass /32 routes for the WG endpoint and any
+/// caller-supplied control-plane hosts so encrypted UDP and FIPS
+/// handshakes keep escaping via the original default route.
 ///
 /// **This is the dangerous mode** — if the WG handshake fails after
 /// this call returns, the host has lost its way to the internet
@@ -336,6 +337,7 @@ pub fn apply_full_default_route(
     address: &str,
     upstream_endpoint: SocketAddr,
     mtu: u16,
+    extra_ipv4_bypass_hosts: &[Ipv4Addr],
 ) -> Result<FullDefaultRoute> {
     let upstream_ip = upstream_endpoint.ip();
     let address_ip = address
@@ -387,17 +389,33 @@ pub fn apply_full_default_route(
     // Drop. Do this before touching anything routing-related.
     let original_default = capture_default_route()?;
 
-    // 3. Install the bypass /32 for the WG endpoint via the original
-    // default gateway. This MUST exist before we swap the default,
-    // otherwise the encrypted UDP would loop back into the tun.
-    install_endpoint_bypass(&upstream_ip, &original_default)?;
+    // 3. Install bypass /32 routes via the original default gateway.
+    // These MUST exist before we swap the default, otherwise the WG
+    // encrypted UDP and mesh control-plane handshakes would loop back
+    // into the tun.
+    let bypass_targets = full_default_route_bypass_targets(upstream_ip, extra_ipv4_bypass_hosts);
+    let mut installed_bypass_targets = Vec::with_capacity(bypass_targets.len());
+    for target in &bypass_targets {
+        if let Err(error) = install_endpoint_bypass(target, &original_default) {
+            for installed in installed_bypass_targets.iter().rev() {
+                delete_endpoint_bypass(installed, &original_default);
+            }
+            return Err(error);
+        }
+        installed_bypass_targets.push(*target);
+    }
 
     // 4. Swap the default route to the WG tun.
-    install_default_via_iface(iface, &address_ip)?;
+    if let Err(error) = install_default_via_iface(iface, &address_ip) {
+        for installed in installed_bypass_targets.iter().rev() {
+            delete_endpoint_bypass(installed, &original_default);
+        }
+        return Err(error);
+    }
 
     Ok(FullDefaultRoute {
         iface: iface.to_string(),
-        bypass_target: upstream_ip,
+        bypass_targets,
         original_default,
     })
 }
@@ -408,8 +426,29 @@ pub struct FullDefaultRoute {
     // `ip route show default` line for restore and never touches iface.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     iface: String,
-    bypass_target: IpAddr,
+    bypass_targets: Vec<IpAddr>,
     original_default: CapturedDefaultRoute,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn full_default_route_bypass_targets(
+    upstream_ip: IpAddr,
+    extra_ipv4_bypass_hosts: &[Ipv4Addr],
+) -> Vec<IpAddr> {
+    let mut targets = Vec::with_capacity(1 + extra_ipv4_bypass_hosts.len());
+    targets.push(upstream_ip);
+    targets.extend(extra_ipv4_bypass_hosts.iter().copied().map(IpAddr::V4));
+    targets.sort_unstable();
+    targets.dedup();
+    targets
+}
+
+#[cfg(target_os = "macos")]
+fn canonical_ipv4_bypass_hosts(hosts: &[Ipv4Addr]) -> Vec<Ipv4Addr> {
+    let mut hosts = hosts.to_vec();
+    hosts.sort_unstable();
+    hosts.dedup();
+    hosts
 }
 
 /// Captured underlay default route, used to restore on Drop. The
@@ -529,6 +568,10 @@ fn install_endpoint_bypass(target: &IpAddr, original: &CapturedDefaultRoute) -> 
     }
     #[cfg(target_os = "macos")]
     {
+        if target_str == original.gateway {
+            return Ok(());
+        }
+
         // The daemon installs 0/1 + 128/1 routes through the WG utun.
         // The WG server itself must be an unscoped host route so
         // ordinary lookups still prefer the underlay gateway.
@@ -537,14 +580,7 @@ fn install_endpoint_bypass(target: &IpAddr, original: &CapturedDefaultRoute) -> 
             .arg("delete")
             .arg("-host")
             .arg(&target_str)
-            .arg("-ifscope")
-            .arg(&original.interface)
-            .status();
-        let _ = ProcessCommand::new("route")
-            .arg("-n")
-            .arg("delete")
-            .arg("-host")
-            .arg(&target_str)
+            .arg(&original.gateway)
             .status();
         run_checked(
             ProcessCommand::new("route")
@@ -556,6 +592,36 @@ fn install_endpoint_bypass(target: &IpAddr, original: &CapturedDefaultRoute) -> 
         )?;
     }
     Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn delete_endpoint_bypass(target: &IpAddr, original: &CapturedDefaultRoute) {
+    #[cfg(target_os = "linux")]
+    let _ = original;
+
+    let target_str = target.to_string();
+    #[cfg(target_os = "linux")]
+    {
+        let _ = ProcessCommand::new("ip")
+            .arg("route")
+            .arg("del")
+            .arg(format!("{target_str}/32"))
+            .status();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if target_str == original.gateway {
+            return;
+        }
+
+        let _ = ProcessCommand::new("route")
+            .arg("-n")
+            .arg("delete")
+            .arg("-host")
+            .arg(&target_str)
+            .arg(&original.gateway)
+            .status();
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -601,7 +667,6 @@ impl FullDefaultRoute {
     /// Cleanup explicitly. Returning a `Result` lets the caller see
     /// what failed; on Drop the result is ignored.
     pub fn revert(&mut self) -> Result<()> {
-        let target_str = self.bypass_target.to_string();
         // Restore the original default route FIRST so the host has a
         // working route to the internet again before we delete the
         // bypass for the WG endpoint.
@@ -616,11 +681,9 @@ impl FullDefaultRoute {
                 command.arg(arg);
             }
             run_checked(&mut command)?;
-            let _ = ProcessCommand::new("ip")
-                .arg("route")
-                .arg("del")
-                .arg(format!("{target_str}/32"))
-                .status();
+            for target in &self.bypass_targets {
+                delete_endpoint_bypass(target, &self.original_default);
+            }
         }
         #[cfg(target_os = "macos")]
         {
@@ -663,29 +726,9 @@ impl FullDefaultRoute {
                         .arg(&self.original_default.gateway),
                 )?;
             }
-            let _ = ProcessCommand::new("route")
-                .arg("-n")
-                .arg("delete")
-                .arg("-host")
-                .arg(&target_str)
-                .arg(&self.original_default.gateway)
-                .arg("-ifscope")
-                .arg(&self.original_default.interface)
-                .status();
-            let _ = ProcessCommand::new("route")
-                .arg("-n")
-                .arg("delete")
-                .arg("-host")
-                .arg(&target_str)
-                .arg("-ifscope")
-                .arg(&self.original_default.interface)
-                .status();
-            let _ = ProcessCommand::new("route")
-                .arg("-n")
-                .arg("delete")
-                .arg("-host")
-                .arg(&target_str)
-                .status();
+            for target in &self.bypass_targets {
+                delete_endpoint_bypass(target, &self.original_default);
+            }
         }
         Ok(())
     }
@@ -840,6 +883,7 @@ pub struct DaemonWgUpstream {
     // tunnel; dropping it auto-removes the utun device on macOS.
     _tun: Arc<TunSocket>,
     config_fingerprint: WireGuardExitFingerprint,
+    extra_ipv4_bypass_hosts: Vec<Ipv4Addr>,
 }
 
 #[cfg(target_os = "windows")]
@@ -885,6 +929,7 @@ struct WindowsNativeWireGuardTunnel {
 pub async fn apply_daemon_wg_upstream(
     config: &WireGuardExitConfig,
     handshake_timeout: Duration,
+    extra_ipv4_bypass_hosts: &[Ipv4Addr],
 ) -> Result<DaemonWgUpstream> {
     let fingerprint = WireGuardExitFingerprint::from_config(config);
     let interface_hint =
@@ -921,7 +966,13 @@ pub async fn apply_daemon_wg_upstream(
     }
 
     let mtu = if config.mtu > 0 { config.mtu } else { 1420 };
-    let full_route = match apply_full_default_route(&actual_iface, &config.address, upstream, mtu) {
+    let full_route = match apply_full_default_route(
+        &actual_iface,
+        &config.address,
+        upstream,
+        mtu,
+        extra_ipv4_bypass_hosts,
+    ) {
         Ok(route) => route,
         Err(error) => {
             runtime.shutdown().await;
@@ -936,6 +987,7 @@ pub async fn apply_daemon_wg_upstream(
         full_route: Some(full_route),
         _tun: tun,
         config_fingerprint: fingerprint,
+        extra_ipv4_bypass_hosts: canonical_ipv4_bypass_hosts(extra_ipv4_bypass_hosts),
     })
 }
 
@@ -945,8 +997,13 @@ impl DaemonWgUpstream {
     /// equivalent to a fresh apply for `new_config`. Used by the
     /// reconcile loop to short-circuit a teardown+rebuild on every
     /// tick.
-    pub fn matches(&self, new_config: &WireGuardExitConfig) -> bool {
+    pub fn matches(
+        &self,
+        new_config: &WireGuardExitConfig,
+        extra_ipv4_bypass_hosts: &[Ipv4Addr],
+    ) -> bool {
         self.config_fingerprint == WireGuardExitFingerprint::from_config(new_config)
+            && self.extra_ipv4_bypass_hosts == canonical_ipv4_bypass_hosts(extra_ipv4_bypass_hosts)
     }
 
     /// Tear down the WG upstream cleanly: restore the default route
@@ -1848,6 +1905,50 @@ async fn apply_daemon_wg_upstream_userspace(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn full_default_route_bypass_targets_dedupes_upstream_and_extra_hosts() {
+        let targets = full_default_route_bypass_targets(
+            IpAddr::V4("198.51.100.10".parse().expect("ip")),
+            &[
+                "203.0.113.7".parse().expect("ip"),
+                "198.51.100.10".parse().expect("ip"),
+                "203.0.113.7".parse().expect("ip"),
+                "192.0.2.5".parse().expect("ip"),
+            ],
+        );
+        assert_eq!(
+            targets,
+            vec![
+                IpAddr::V4("192.0.2.5".parse().expect("ip")),
+                IpAddr::V4("198.51.100.10".parse().expect("ip")),
+                IpAddr::V4("203.0.113.7".parse().expect("ip")),
+            ]
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn full_default_route_bypass_targets_keeps_ipv6_upstream_with_ipv4_extras() {
+        let targets = full_default_route_bypass_targets(
+            IpAddr::V6("2001:db8::10".parse().expect("ip")),
+            &[
+                "203.0.113.7".parse().expect("ip"),
+                "192.0.2.5".parse().expect("ip"),
+                "203.0.113.7".parse().expect("ip"),
+            ],
+        );
+        assert_eq!(
+            targets,
+            vec![
+                IpAddr::V4("192.0.2.5".parse().expect("ip")),
+                IpAddr::V4("203.0.113.7".parse().expect("ip")),
+                IpAddr::V6("2001:db8::10".parse().expect("ip")),
+            ]
+        );
+    }
+
     #[test]
     fn parses_windows_default_route_from_route_print() {
         // Synthetic `route print -4 0.0.0.0` output. Only the


### PR DESCRIPTION
Adds macOS WG upstream bypass routes for FIPS control-plane and peer transport IPv4 hosts, and rebuilds the upstream tunnel when bypass hosts change.