### PR TITLE
Fix macOS VPN toggle on macOS 26 (AuthorizationExecuteWithPrivileges no longer in RTLD_DEFAULT)

### DIFF
--- a/macos/Sources/PrivilegedCommandRunner.swift
+++ b/macos/Sources/PrivilegedCommandRunner.swift
@@ -140,13 +140,35 @@ final class AuthorizationServicesPrivilegedCommandRunner: PrivilegedCommandRunne
             UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
             UnsafeMutablePointer<UnsafeMutablePointer<FILE>?>?
         ) -> OSStatus
-        guard let sym = dlsym(
-            UnsafeMutableRawPointer(bitPattern: -2),
-            "AuthorizationExecuteWithPrivileges"
-        ) else {
+        guard let sym = Self.resolveExecuteWithPrivilegesSymbol() else {
             return errAuthorizationInternal
         }
         let fn = unsafeBitCast(sym, to: FnT.self)
         return fn(authRef, pathToTool, [], args, communicationsPipe)
+    }
+
+    /// Resolves the (long-deprecated) `AuthorizationExecuteWithPrivileges`
+    /// symbol at runtime.
+    ///
+    /// macOS 26 stopped exposing this symbol through the `RTLD_DEFAULT`
+    /// namespace, so `dlsym((void*)-2, ...)` now returns `nil` even though the
+    /// function still ships in `Security.framework`. The result was that the
+    /// privileged `nvpn` invocation silently never ran and the VPN toggle
+    /// reverted to off with no auth prompt (see issue #3). Keep the
+    /// `RTLD_DEFAULT` lookup first for older systems, then fall back to an
+    /// explicit `Security.framework` handle, which still resolves on macOS 26.
+    private static func resolveExecuteWithPrivilegesSymbol() -> UnsafeMutableRawPointer? {
+        let name = "AuthorizationExecuteWithPrivileges"
+        if let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), name) {
+            return sym
+        }
+        let securityPath = "/System/Library/Frameworks/Security.framework/Security"
+        guard let handle = dlopen(securityPath, RTLD_LAZY) else {
+            return nil
+        }
+        // The handle is intentionally left resident for the process lifetime;
+        // Security.framework is already loaded, so this does not leak a real
+        // resource.
+        return dlsym(handle, name)
     }
 }


### PR DESCRIPTION
## Problem

On macOS 26 the menubar app's VPN toggle flips straight back to **Off** with no Touch ID / password prompt, so the tunnel never comes up. Reported in #3.

## Root cause

`AuthorizationServicesPrivilegedCommandRunner` runs the bundled `nvpn` CLI as root via `AuthorizationExecuteWithPrivileges`, resolved with `RTLD_DEFAULT`:

```swift
dlsym(UnsafeMutableRawPointer(bitPattern: -2), "AuthorizationExecuteWithPrivileges")
```

macOS 26 **stopped exposing this symbol through the `RTLD_DEFAULT` namespace**, so the lookup returns `nil`, `executeWithPrivileges` returns `errAuthorizationInternal`, and the privileged invocation silently never runs — the toggle reverts to off with no prompt. (The existing comment already anticipated this: *"If Apple removes it we'll need to migrate to a privileged helper tool."*)

The symbol still **ships in `Security.framework`** — it's just no longer in the default namespace. Verified on **macOS 26.2 (build 25C56)** with a small dlsym probe:

```
AuthorizationExecuteWithPrivileges via RTLD_DEFAULT:        NULL (removed/hidden)
...via explicit Security.framework handle:                  RESOLVED (present)
```

## Fix

Keep the `RTLD_DEFAULT` lookup first (older systems), then fall back to an explicit `Security.framework` handle, which still resolves on macOS 26. Single function, no behavior change on older macOS.

## Validation

- **dlsym level:** confirmed the explicit-handle path resolves the symbol on macOS 26.2 while the `RTLD_DEFAULT` path returns `nil`.
- **End-to-end:** running the same bundled CLI with privileges (`sudo nvpn start --connect`, `sudo nvpn service install`) brings the tunnel up and peers correctly — confirming AEWP-as-root is the only missing link.
- I could not produce a **signed** Xcode build locally, so please confirm with a signed build that the auth dialog now appears from the app itself.

## Notes

This revives the existing (deprecated) AEWP path as a low-risk way to restore macOS 26 support now. The long-term fix is still migrating to an SMAppService privileged helper, as the code comment notes.

Fixes #3