### PR TITLE
Fix macOS service status for KeepAlive daemons

### DIFF
--- a/crates/nostr-vpn-cli/src/macos_service.rs
+++ b/crates/nostr-vpn-cli/src/macos_service.rs
@@ -301,12 +301,15 @@ pub(super) fn macos_service_print(config_path: &Path) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 pub(super) fn macos_service_print_is_running(print_output: &str) -> bool {
+    // A KeepAlive daemon idling between (re)spawns reports `spawn scheduled` or
+    // `waiting`, not `running`; only `not running` means it is actually down.
     print_output
         .lines()
         .map(str::trim)
-        .any(|line| line == "state = running")
+        .filter_map(|line| line.strip_prefix("state = "))
+        .any(|state| matches!(state, "running" | "spawn scheduled" | "waiting"))
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/nostr-vpn-cli/src/tests/service_cli.rs
+++ b/crates/nostr-vpn-cli/src/tests/service_cli.rs
@@ -63,6 +63,20 @@ fn macos_service_disabled_parser_extracts_disabled_state() {
 }
 
 #[test]
+fn macos_service_print_is_running_accepts_keepalive_states() {
+    for state in ["running", "spawn scheduled", "waiting"] {
+        let output = format!("system/to.nostrvpn.nvpn = {{\n\tstate = {state}\n}}\n");
+        assert!(
+            crate::macos_service::macos_service_print_is_running(&output),
+            "expected running for state = {state}"
+        );
+    }
+    assert!(!crate::macos_service::macos_service_print_is_running(
+        "system/to.nostrvpn.nvpn = {\n\tstate = not running\n}\n"
+    ));
+}
+
+#[test]
 fn macos_service_plist_runs_service_supervised_daemon() {
     let plist = crate::macos_service::macos_service_plist_content(
         "to.nostrvpn.nvpn",


### PR DESCRIPTION
`macos_service_print_is_running` only matched `state = running`, but a KeepAlive LaunchDaemon idling between (re)spawns reports `state = spawn scheduled` (or `waiting`) — so `nvpn service status` reported a live daemon as stopped. Broaden the accepted states and add a test.