### PR TITLE
docs: fix Title Case heading capitalization in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-## StartOS package
+## StartOS Package
 
 The StartOS package lives in `startos/` and uses the Dockerfile at
 `umbrel/Dockerfile` to build the service image. The package supports `x86_64`


### PR DESCRIPTION
## Description
This PR fixes section heading Title Case capitalization in `CONTRIBUTING.md`.

## Details
Updated `## StartOS package` -> `## StartOS Package` to match Title Case header conventions.