### PR TITLE
Update FIPS to 0.4.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1674,7 +1674,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1816,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1900,9 +1900,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fips-core"
-version = "0.4.54"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012825ab6024ee7f042c01879ac8a3268e39cd40a4702173ffccdb26b2469cf"
+checksum = "95762d6e4787aae6fee1df6e7d6e3cb2c0447a87f779c0acb99c09b3a2113458"
 dependencies = [
  "base64 0.22.1",
  "bluer",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "fips-endpoint"
-version = "0.4.54"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cdeb99b20b067812e767c746493d09830a170a1781190e995629f57ce1b218"
+checksum = "840d21774345687a7cf4efb76b60ed2ef2a90e619ff243b802b1842bd2a81d0e"
 dependencies = [
  "fips-core",
 ]
@@ -2624,7 +2624,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3857,7 +3857,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4504,7 +4504,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4541,7 +4541,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5001,7 +5001,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5578,7 +5578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5755,7 +5755,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ cashu-service = { version = "0.4.2", default-features = false }
 cashu = { version = "=0.17.3", default-features = false }
 clap = { version = "4.5", features = ["derive", "env"] }
 dirs = "6"
-fips-endpoint = "=0.4.54"
-fips-core = { version = "=0.4.54", features = ["webrtc-transport"] }
+fips-endpoint = "=0.4.56"
+fips-core = { version = "=0.4.56", features = ["webrtc-transport"] }
 fips-tcp = "=0.2.0"
 fips-tcp-endpoint = "=0.2.0"
 futures = "0.3"

--- a/crates/nostr-vpn-cli/src/fips_private_mesh/runtime_status.rs
+++ b/crates/nostr-vpn-cli/src/fips_private_mesh/runtime_status.rs
@@ -1,5 +1,5 @@
 fn endpoint_link_refreshable_after_stale_participant(peer_link: &FipsEndpointPeer) -> bool {
-    peer_link.direct_probe_pending
+    peer_link.direct_probe_pending && !peer_link.connected
 }
 
 fn endpoint_path_refresh_due(

--- a/crates/nostr-vpn-cli/src/fips_private_mesh/tests_status.rs
+++ b/crates/nostr-vpn-cli/src/fips_private_mesh/tests_status.rs
@@ -114,6 +114,7 @@
         assert!(!super::endpoint_path_refresh_due(&peer, Some(120), 123));
 
         peer.connected = true;
+        peer.direct_probe_pending = true;
         assert!(
             !super::endpoint_path_refresh_due(&peer, Some(80), 123),
             "connected endpoint links should not be refreshed from wrapper-level participant staleness alone"
@@ -121,14 +122,14 @@
     }
 
     #[test]
-    fn endpoint_path_refresh_prefers_data_freshness_over_control_freshness() {
+    fn disconnected_endpoint_path_refresh_prefers_data_freshness() {
         let peer = FipsEndpointPeer {
             npub: Keys::generate()
                 .public_key()
                 .to_bech32()
                 .expect("npub"),
             node_addr: NodeAddr::from_bytes([7; 16]),
-            connected: true,
+            connected: false,
             transport_addr: Some("203.0.113.7:9000".to_string()),
             transport_type: Some("udp".to_string()),
             link_id: 43,
@@ -155,7 +156,7 @@
 
         assert!(
             super::endpoint_path_refresh_due(&peer, Some(80), 123),
-            "stale tunnel data should refresh direct probes even if control traffic stayed fresh"
+            "stale tunnel data should refresh a disconnected direct probe"
         );
         assert!(
             !super::endpoint_path_refresh_due(&peer, Some(120), 123),

--- a/linux/Cargo.lock
+++ b/linux/Cargo.lock
@@ -148,7 +148,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1638,7 +1638,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1780,7 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1874,9 +1874,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fips-core"
-version = "0.4.54"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012825ab6024ee7f042c01879ac8a3268e39cd40a4702173ffccdb26b2469cf"
+checksum = "95762d6e4787aae6fee1df6e7d6e3cb2c0447a87f779c0acb99c09b3a2113458"
 dependencies = [
  "base64 0.22.1",
  "bluer",
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "fips-endpoint"
-version = "0.4.54"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cdeb99b20b067812e767c746493d09830a170a1781190e995629f57ce1b218"
+checksum = "840d21774345687a7cf4efb76b60ed2ef2a90e619ff243b802b1842bd2a81d0e"
 dependencies = [
  "fips-core",
 ]
@@ -2842,7 +2842,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3927,7 +3927,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4532,7 +4532,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4569,7 +4569,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5029,7 +5029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5585,7 +5585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5781,7 +5781,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- bump the exact `fips-core` and `fips-endpoint` pins from 0.4.54 to 0.4.56
- refresh the root and Linux lockfiles

## Why

FIPS 0.4.56 contains the published repair for [jmcorgan/fips#7](https://github.com/jmcorgan/fips/issues/7). During an FSP rekey, packet loss or reordering could leave the endpoints using different key epochs, causing AEAD failures and dropped connectivity until they reconverged.

The updated FIPS release overlaps live receive epochs, promotes a pending epoch only after authenticated traffic proves peer progress, and retransmits the final rekey handshake message with a bounded retry budget. nVPN currently pins 0.4.54, so it does not receive that repair.

This PR deliberately does not change nVPN's peer-liveness or `mesh_ready` semantics. Those are separate status contracts and are not needed to adopt the protocol fix.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p nostr-vpn-core` (pass)
- `cargo test -p nvpn --bin nvpn -- --skip hanging_mint_does_not_block_daemon_poll_or_next_refund_channel --skip relative_config_path_has_the_same_absolute_identity` (535 passed)
- `cargo test -p nvpn join_request_ipc::tests::relative_config_path_has_the_same_absolute_identity -- --exact` from a short checkout path (pass)
- real-UDP FIPS control delivery, late-peer delivery, and local endpoint/rebind tests (pass)

The skipped paid-exit timing test also fails unchanged on upstream `master`; it is unrelated to the dependency update.

Field validation used a three-node mixed macOS/Linux mesh. Sustained SSH checks and a 240-packet overlay/direct comparison completed without peer-specific AEAD errors in steady-state logs after convergence.

This fixes one specific rekey failure mode. It does not claim to resolve separate roster, discovery, routing, or underlay failures.
